### PR TITLE
Make Rocket support intent scheme in FCM push_open_url payload

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -64,6 +64,7 @@
 
                 <data android:scheme="http" />
                 <data android:scheme="https" />
+                <data android:scheme="intent" />
                 <data android:mimeType="text/html" />
                 <data android:mimeType="text/plain" />
                 <data android:mimeType="application/xhtml+xml" />

--- a/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
+++ b/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
@@ -73,6 +73,7 @@ import org.mozilla.focus.utils.Settings;
 import org.mozilla.focus.utils.ShortcutUtils;
 import org.mozilla.focus.utils.StorageUtils;
 import org.mozilla.focus.utils.SupportUtils;
+import org.mozilla.rocket.deeplink.IntentScheme;
 import org.mozilla.urlutils.UrlUtils;
 import org.mozilla.focus.viewmodel.BookmarkViewModel;
 import org.mozilla.focus.web.GeoPermissionCache;
@@ -191,7 +192,14 @@ public class MainActivity extends LocaleAwareAppCompatActivity implements Fragme
             } else if (intent.getStringExtra(RocketMessagingService.PUSH_OPEN_URL) != null) {
                 // This happens when the app is not running, and the user clicks on the push
                 // notification with payload "PUSH_OPEN_URL"
-                pendingUrl = intent.getStringExtra(RocketMessagingService.PUSH_OPEN_URL);
+                final String url = intent.getStringExtra(RocketMessagingService.PUSH_OPEN_URL);
+
+                // If this intent can be handle by other app, let them handle it.
+                if (IntentScheme.isIntent(this, url)) {
+                    return;
+                } else {
+                    pendingUrl = url;
+                }
             } else {
                 if (Settings.getInstance(this).shouldShowFirstrun()) {
                     this.screenNavigator.addFirstRunScreen();
@@ -320,9 +328,15 @@ public class MainActivity extends LocaleAwareAppCompatActivity implements Fragme
         } else if (intent.getStringExtra(RocketMessagingService.PUSH_OPEN_URL) != null) {
             // This happens when the app is running in background, and the user clicks on the push
             // notification with payload "PUSH_OPEN_URL"
-            pendingUrl = intent.getStringExtra(RocketMessagingService.PUSH_OPEN_URL);
-            dismissAllMenus();
-            TabTray.dismiss(getSupportFragmentManager());
+            final String url = intent.getStringExtra(RocketMessagingService.PUSH_OPEN_URL);
+            // If this intent can be handle by other app, let them handle it.
+            if (IntentScheme.isIntent(this, url)) {
+                return;
+            } else {
+                pendingUrl = url;
+                dismissAllMenus();
+                TabTray.dismiss(getSupportFragmentManager());
+            }
         }
 
         // We do not care about the previous intent anymore. But let's remember this one.

--- a/app/src/main/java/org/mozilla/focus/utils/AppConstants.java
+++ b/app/src/main/java/org/mozilla/focus/utils/AppConstants.java
@@ -8,6 +8,7 @@ package org.mozilla.focus.utils;
 import org.mozilla.focus.BuildConfig;
 
 public final class AppConstants {
+    public static final String LAUNCHER_ACTIVITY = "org.mozilla.rocket.activity.MainActivity";
     private static final String BUILD_TYPE_DEBUG = "debug";
     private static final String BUILD_TYPE_FIREBASE = "firebase";
     private static final String BUILD_TYPE_BETA = "beta";

--- a/app/src/main/java/org/mozilla/rocket/deeplink/IntentScheme.kt
+++ b/app/src/main/java/org/mozilla/rocket/deeplink/IntentScheme.kt
@@ -1,0 +1,91 @@
+package org.mozilla.rocket.deeplink
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.util.Log
+import org.mozilla.focus.activity.MainActivity
+import org.mozilla.focus.utils.AppConstants
+import org.mozilla.focus.utils.IntentUtils
+
+class IntentScheme {
+    companion object {
+
+        private const val TAG = "IntentScheme"
+        public const val SCHEME = "intent"
+        private const val EXTRA_START = "S."
+        private const val DATA = "data"
+        private const val PACKAGE = "package"
+        private const val ACTION = "action"
+        private const val CATEGORY = "category"
+        private const val COMPONENT = "component"
+        private const val FACLLBACK_URL = "S.browser_fallback_url"
+
+        @JvmStatic
+        fun isIntent(context: Context, url: String): Boolean {
+            return parse(context, Uri.parse(url)) != null
+        }
+
+        @JvmStatic
+        fun parse(context: Context, uri: Uri): Intent? {
+            if (SCHEME != uri.scheme) {
+                return null
+            }
+            val deepLink = Intent().apply {
+
+                for (query in uri.queryParameterNames) {
+                    if (query.startsWith(EXTRA_START)) {
+                        val extra = query.substring(EXTRA_START.length)
+                        putExtra(extra, uri.getQueryParameter(query))
+                    }
+                }
+                uri.getQueryParameter(DATA)?.apply { data = Uri.parse(this) }
+                uri.getQueryParameter(PACKAGE)?.apply { setPackage(this) }
+                uri.getQueryParameter(ACTION)?.apply { action = this }
+                uri.getQueryParameters(CATEGORY)?.apply {
+                    this.forEach {
+                        addCategory(it)
+                    }
+                }
+                uri.getQueryParameter(COMPONENT)?.apply { component = ComponentName(context, this) }
+            }
+            try {
+                // if the intent can be handle by other apps, it's a valid intent scheme
+                val resolveActivity = deepLink.resolveActivity(context.packageManager)
+
+                return if (resolveActivity != null && AppConstants.LAUNCHER_ACTIVITY != resolveActivity.className) {
+                    // if other app can handle this, we return the intent and let caller to use it and exit early
+                    deepLink
+                } else {
+                    // if we are the default handler, return false and continue
+                    return fallback(context, uri)
+
+                }
+            } catch (e: IllegalStateException) {
+                Log.e(TAG, "This intent is not supported ", e)
+
+                return fallback(context, uri)
+            }
+        }
+
+        /*
+         * When an intent could not be resolved, or an external application could not be launched, then the
+         * user will be redirected to the fallback URL if it was given.
+         */
+        private fun fallback(context: Context, uri: Uri): Intent? {
+            val fallbackUrl = uri.getQueryParameter(FACLLBACK_URL)
+            if (fallbackUrl == null) {
+                return null
+            } else {
+                return Intent().apply {
+                    setComponent(ComponentName(context, AppConstants.LAUNCHER_ACTIVITY))
+                    setAction(Intent.ACTION_VIEW)
+                    setData((Uri.parse(fallbackUrl)))
+                    putExtra(IntentUtils.EXTRA_OPEN_NEW_TAB, true)
+                }
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
This will work when
1. We send the valid link (intent://....)  in FCM payload push_open_url. After the notification displays, the user clicks on the notification content. 
2. If the user clicks on a valid link (intent://....) in a third party app and selects Rocket to handle it.

**Syntax**
intent://<HOST: not used>?package=[string]&action=[string]&category=[string]&component=[string]&scheme=[string]&category=[string]&category=[string]&S.extra_name=[string]&S.browser_fallback_url=[string]

**Parameters**
intent : scheme
S. :  paramters start with S. will be extra. "S." will be replaced. You can have more than one extra
data : data Uri of an intent
package : package of an intent
action : action of an intent
category : category of an intent you can have more than one category
component : catecomponentory of an intent 
S.browser_fallback_url : if the intent can't be resolved, the browser will open this link



Examples:

**Set Rocket(Dev) as default browser:**
intent://set_default_browser?action=android.settings.MANAGE_DEFAULT_APPS_SETTINGS&package=org.mozilla.rocket.debug.firebase

**Open zxing QR code scanner & open a web page if it's not installed**
intent://install_focus;scheme=zxing;package=com.google.zxing.client.android;S.browser_fallback_url=http%3A%2F%2Fzxing.org





I reference the spec in https://developer.chrome.com/multidevice/android/intents