### PR TITLE
Add telemetry pings to better understand Firebase lifecycle

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/FirstrunFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/FirstrunFragment.kt
@@ -49,8 +49,6 @@ class FirstrunFragment : Fragment(), View.OnClickListener, Screen {
 
         exitTransition = transition
 
-        // We will send a telemetry event whenever a new firstrun page is shown. However this page
-        // listener won't fire for the initial page we are showing. So we are going to firing here.
         isTelemetryValid = true
         telemetryStartTimestamp = System.currentTimeMillis()
     }

--- a/app/src/main/java/org/mozilla/focus/fragment/FirstrunFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/FirstrunFragment.kt
@@ -104,6 +104,11 @@ class FirstrunFragment : Fragment(), View.OnClickListener, Screen {
         return view
     }
 
+    override fun onResume() {
+        super.onResume()
+        TelemetryWrapper.startFirstRunEvent()
+    }
+
     override fun onPause() {
         super.onPause()
         isTelemetryValid = false

--- a/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
+++ b/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
@@ -337,6 +337,18 @@ object TelemetryWrapper {
     }
 
     @TelemetryDoc(
+            name = "Start First Run",
+            category = Category.ACTION,
+            method = Method.SHOW,
+            `object` = Object.FIRSTRUN,
+            value = "null",
+            extras = [])
+    @JvmStatic
+    fun startFirstRunEvent() {
+        EventBuilder(Category.ACTION, Method.SHOW, Object.FIRSTRUN).queue()
+    }
+
+    @TelemetryDoc(
             name = "Finish First Run",
             category = Category.ACTION,
             method = Method.SHOW,

--- a/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
+++ b/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
@@ -90,6 +90,7 @@ object TelemetryWrapper {
         const val OPEN = "open"
         const val SHOW = "show"
         const val LAUNCH = "launch"
+        const val INIT = "init"
     }
 
     internal object Object {
@@ -121,6 +122,7 @@ object TelemetryWrapper {
         const val DOORHANGER = "doorhanger"
         const val VPN_DOORHANGER = "vpn_doorhanger"
         const val QUICK_SEARCH = "quicksearch"
+        const val FIREBASE = "firebase"
     }
 
     object Value {
@@ -304,6 +306,20 @@ object TelemetryWrapper {
                     .getDefaultSearchEngine(context)
                     .identifier
         }
+    }
+
+    @TelemetryDoc(
+            name = "Firebase RemoteConfig Fetched",
+            category = Category.ACTION,
+            method = Method.INIT,
+            `object` = Object.FIREBASE,
+            value = "null",
+            extras = [TelemetryExtra(name = Extra.TO, value = "true,false")]
+    )
+    @JvmStatic
+    fun firebaseRemoteConfigFetched() {
+        EventBuilder(Category.ACTION, Method.INIT, Object.FIREBASE)
+                .queue()
     }
 
     @TelemetryDoc(

--- a/app/src/main/java/org/mozilla/focus/urlinput/UrlInputContract.java
+++ b/app/src/main/java/org/mozilla/focus/urlinput/UrlInputContract.java
@@ -26,6 +26,13 @@ public class UrlInputContract {
          * @param texts
          */
         void setSuggestions(@Nullable List<CharSequence> texts);
+
+        /**
+         * Set quick search view's visibility
+         *
+         * @param visible
+         */
+        void setQuickSearchVisible(boolean visible);
     }
 
     interface Presenter {

--- a/app/src/main/java/org/mozilla/focus/urlinput/UrlInputFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/urlinput/UrlInputFragment.kt
@@ -47,7 +47,8 @@ class UrlInputFragment : Fragment(), UrlInputContract.View, View.OnClickListener
     private lateinit var suggestionView: FlowLayout
     private lateinit var clearView: View
     private lateinit var dismissView: View
-    private lateinit var quickSearchView: RecyclerView
+    private lateinit var quickSearchRecyclerView: RecyclerView
+    private lateinit var quickSearchView: ViewGroup
     private var lastRequestTime: Long = 0
     private var autoCompleteInProgress: Boolean = false
     private var allowSuggestion: Boolean = false
@@ -97,8 +98,9 @@ class UrlInputFragment : Fragment(), UrlInputContract.View, View.OnClickListener
     }
 
     private fun initQuickSearch(view: View) {
-        quickSearchView = view.findViewById(R.id.quick_search_recycler_view)
-        quickSearchView.layoutManager = LinearLayoutManager(context, LinearLayoutManager.HORIZONTAL, false)
+        quickSearchView = view.findViewById(R.id.quick_search_container)
+        quickSearchRecyclerView = view.findViewById(R.id.quick_search_recycler_view)
+        quickSearchRecyclerView.layoutManager = LinearLayoutManager(context, LinearLayoutManager.HORIZONTAL, false)
         val quickSearchAdapter = QuickSearchAdapter(fun(quickSearch: QuickSearch) {
             if (TextUtils.isEmpty(urlView.text)) {
                 openUrl(quickSearch.homeUrl)
@@ -107,7 +109,7 @@ class UrlInputFragment : Fragment(), UrlInputContract.View, View.OnClickListener
             }
             TelemetryWrapper.clickQuickSearchEngine(quickSearch.name)
         })
-        quickSearchView.adapter = quickSearchAdapter
+        quickSearchRecyclerView.adapter = quickSearchAdapter
         Inject.obtainQuickSearchViewModel(activity).quickSearchObservable.observe(
                 viewLifecycleOwner,
                 Observer { quickSearchList ->
@@ -265,6 +267,14 @@ class UrlInputFragment : Fragment(), UrlInputContract.View, View.OnClickListener
             item.setOnClickListener(this)
             item.setOnLongClickListener(this)
             this.suggestionView.addView(item)
+        }
+    }
+
+    override fun setQuickSearchVisible(visible: Boolean) {
+        if (visible) {
+            quickSearchView.visibility = View.VISIBLE
+        } else {
+            quickSearchView.visibility = View.GONE
         }
     }
 

--- a/app/src/main/java/org/mozilla/focus/urlinput/UrlInputPresenter.java
+++ b/app/src/main/java/org/mozilla/focus/urlinput/UrlInputPresenter.java
@@ -57,9 +57,10 @@ public class UrlInputPresenter implements UrlInputContract.Presenter {
 
         if (input.length() == 0) {
             this.view.setSuggestions(null);
+            this.view.setQuickSearchVisible(false);
             return;
         }
-
+        this.view.setQuickSearchVisible(true);
         // No need to provide suggestion for Url input
         if (SupportUtils.isUrl(input.toString())) {
             return;

--- a/app/src/main/java/org/mozilla/focus/utils/FirebaseHelper.java
+++ b/app/src/main/java/org/mozilla/focus/utils/FirebaseHelper.java
@@ -194,7 +194,8 @@ final public class FirebaseHelper extends FirebaseWrapper {
             enableCrashlytics(applicationContext, enable);
             enableAnalytics(applicationContext, enable);
             enableCloudMessaging(applicationContext, RocketMessagingService.class.getName(), enable);
-            enableRemoteConfig(applicationContext, enable);
+            // we only record the firebaseRemoteConfigFetched event when the app is launched.
+            enableRemoteConfig(applicationContext, enable, TelemetryWrapper::firebaseRemoteConfigFetched);
 
             // now firebase has completed state changing,
             changing = false;
@@ -244,7 +245,9 @@ final public class FirebaseHelper extends FirebaseWrapper {
         remoteConfigDefault = null;
         getRemoteConfigDefault(context);
         // Now also need to reset the default config in Firebase if "Send Usage Data" is turned on.
-        enableRemoteConfig(context, TelemetryWrapper.isTelemetryEnabled(context));
+        // We don't need callback for firebaseRemoteConfigFetched cause we only want to record it when
+        // the app is launched.
+        enableRemoteConfig(context, TelemetryWrapper.isTelemetryEnabled(context), null);
     }
 
 

--- a/app/src/main/java/org/mozilla/rocket/urlinput/QuickSearch.kt
+++ b/app/src/main/java/org/mozilla/rocket/urlinput/QuickSearch.kt
@@ -6,6 +6,12 @@ package org.mozilla.rocket.urlinput
 
 import android.net.Uri
 
+/**
+ * The class holds the Quick Search setting.
+ * The order of param is important cause we'll operate them in the same order.
+ * If one day the order needs to be different for each Quick Search setting, we may need
+ * a more complex data structure.
+ */
 data class QuickSearch(
     var name: String,
     var icon: String,
@@ -13,13 +19,21 @@ data class QuickSearch(
     var homeUrl: String,
     var urlPrefix: String = "",
     var urlSuffix: String = "",
-    var patternEncode: Boolean = false
+    var patternEncode: Boolean = false,
+    var permitSpace: Boolean = true
 ) {
     fun generateLink(keyword: String): String {
-        var url = if (patternEncode) {
-            Uri.encode(String.format(searchUrlPattern, keyword))
+        var newKeyword = keyword
+
+        // Remove all spaces in keyword
+        if (!permitSpace) {
+            newKeyword = keyword.replace("\\s".toRegex(), "")
+        }
+
+        val url = if (patternEncode) {
+            Uri.encode(String.format(searchUrlPattern, newKeyword))
         } else {
-            String.format(searchUrlPattern, Uri.encode(keyword))
+            String.format(searchUrlPattern, Uri.encode(newKeyword))
         }
         return urlPrefix + url + urlSuffix
     }

--- a/app/src/main/java/org/mozilla/rocket/urlinput/QuickSearchUtils.kt
+++ b/app/src/main/java/org/mozilla/rocket/urlinput/QuickSearchUtils.kt
@@ -37,7 +37,9 @@ object QuickSearchUtils {
                             jsonObj.optString("homeUrl"),
                             jsonObj.optString("urlPrefix"),
                             jsonObj.optString("urlSuffix"),
-                            jsonObj.optBoolean("patternEncode")
+                            jsonObj.optBoolean("patternEncode"),
+                            jsonObj.optBoolean("permitSpace", true)
+
                     )
                     list.add(element)
                 }

--- a/app/src/main/res/layout/fragment_urlinput.xml
+++ b/app/src/main/res/layout/fragment_urlinput.xml
@@ -63,34 +63,43 @@
 
         </LinearLayout>
 
-        <View
-            android:id="@+id/divider"
+        <android.support.constraint.ConstraintLayout
+            android:id="@+id/quick_search_container"
             android:layout_width="match_parent"
-            android:layout_height="1dp"
+            android:layout_height="wrap_content"
             android:layout_above="@id/input_container"
-            android:background="@color/paletteLightGreyA100" />
+            android:visibility="gone">
 
-        <android.support.v7.widget.RecyclerView
-            android:id="@+id/quick_search_recycler_view"
-            android:layout_width="match_parent"
-            android:layout_height="@dimen/common_margin_m7"
-            android:layout_above="@id/divider"
-            android:clipToPadding="false"
-            android:background="@color/paletteLightGreyB100"
-            android:paddingStart="16dp" />
+            <android.support.v7.widget.RecyclerView
+                android:id="@+id/quick_search_recycler_view"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/common_margin_m7"
+                android:background="@color/paletteLightGreyB100"
+                android:clipToPadding="false"
+                android:paddingStart="16dp" />
 
-        <View
-            android:layout_width="16dp"
-            android:layout_height="@dimen/common_margin_m7"
-            android:layout_alignEnd="@id/quick_search_recycler_view"
-            android:layout_alignTop="@id/quick_search_recycler_view"
-            android:background="@drawable/overflow_mask"/>
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="1dp"
+                android:background="@color/paletteLightGreyA100"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/quick_search_recycler_view" />
+
+            <View
+                android:layout_width="16dp"
+                android:layout_height="@dimen/common_margin_m7"
+                android:layout_alignEnd="@id/quick_search_container"
+                android:layout_alignTop="@id/quick_search_container"
+                android:background="@drawable/overflow_mask"
+                app:layout_constraintEnd_toEndOf="@id/quick_search_recycler_view"
+                app:layout_constraintTop_toTopOf="@id/quick_search_recycler_view" />
+        </android.support.constraint.ConstraintLayout>
 
         <org.mozilla.focus.widget.FlowLayout
             android:id="@+id/search_suggestion"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_above="@id/quick_search_recycler_view"
+            android:layout_above="@id/quick_search_container"
             android:layout_margin="10dp"
             android:animateLayoutChanges="true"
             tools:background="#55FF0000" />

--- a/app/src/main/res/raw/quick_search_engines_common.json
+++ b/app/src/main/res/raw/quick_search_engines_common.json
@@ -15,6 +15,7 @@
     "name": "Instagram",
     "searchUrlPattern": "https://www.instagram.com/explore/tags/%s/",
     "homeUrl": "https://www.instagram.com",
-    "icon": "ic_instagram.png"
+    "icon": "ic_instagram.png",
+    "permitSpace": false
   }
 ]

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -4,7 +4,7 @@ object Versions {
     const val compile_sdk = 28
     const val build_tools = "28.0.3"
     const val version_code = 1
-    const val version_name = "1.1.1"
+    const val version_name = "1.1.2"
     const val android_gradle_plugin = "3.2.1"
     const val gms_oss_licenses_plugin = "0.9.3"
     const val support = "28.0.0"

--- a/docs/events.md
+++ b/docs/events.md
@@ -1,5 +1,6 @@
 | Event | category | method | object | value | extra |
 | ---- | ---- | ---- | ---- | ---- | ---- |
+|Firebase RemoteConfig Fetched|action|init|firebase|"null"|"to=true,false," 
 |Turn on Turbo Mode in First Run|action|change|firstrun|"turbo"|"to=true,false," 
 |Finish First Run|action|show|firstrun|"finish"|"on=time spent on First Run," 
 |App is launched by Launcher|action|launch|app|"launcher"|"" 

--- a/firebase/src/firebase/java/org/mozilla/focus/utils/FirebaseWrapper.java
+++ b/firebase/src/firebase/java/org/mozilla/focus/utils/FirebaseWrapper.java
@@ -295,7 +295,7 @@ abstract class FirebaseWrapper {
     }
 
     // This need to be run in worker thread since FirebaseRemoteConfigSettings has IO access
-    static void enableRemoteConfig(Context context, boolean enable) {
+    static void enableRemoteConfig(Context context, boolean enable, Runnable callback) {
         if (!enable) {
             remoteConfig = null;
             return;
@@ -316,13 +316,13 @@ abstract class FirebaseWrapper {
         if (config.getInfo().getConfigSettings().isDeveloperModeEnabled()) {
             remoteConfigCacheExpirationInSeconds = 0;
         }
-        refreshRemoteConfig();
+        refreshRemoteConfig(callback);
     }
 
     // Call this method to refresh the value in remote config.
     // Client code can access the remote config value in UI thread. But if the work here is not done,
     // it'll still see the old value.
-    private static void refreshRemoteConfig() {
+    private static void refreshRemoteConfig(final Runnable callback) {
         final FirebaseRemoteConfig config = remoteConfig.get();
         if (config == null) {
             return;
@@ -333,6 +333,7 @@ abstract class FirebaseWrapper {
                 if (task.isSuccessful()) {
                     Log.d(TAG, "Firebase RemoteConfig Fetch Successfully ");
                     config.activateFetched();
+                    callback.run();
                 } else {
                     Log.d(TAG, "Firebase RemoteConfig Fetch Failed: ");
                 }

--- a/firebase/src/firebase_no_op/java/org/mozilla/focus/utils/FirebaseWrapper.java
+++ b/firebase/src/firebase_no_op/java/org/mozilla/focus/utils/FirebaseWrapper.java
@@ -91,7 +91,7 @@ abstract class FirebaseWrapper {
     }
 
     // This need to be run in worker thread since FirebaseRemoteConfigSettings has IO access
-    static void enableRemoteConfig(Context context, boolean enable) {
+    static void enableRemoteConfig(Context context, boolean enable, Runnable callback) {
     }
 
     static void setDeveloperModeEnabled(boolean developerModeEnabled) {


### PR DESCRIPTION
We want this data cause we want to verify when below timing, FIrebase RemoteConfing has completed fetching or not:
- The users see onboarding page
- The users finish onboarding page
- The users see the first level toolbar of HomeFragment-
- The users see the second level toolbar of HomeFragment
- The users see the first level toolbar of BrowserFragment.
- The users see the second level toolbar of BrowserFragment.

Confirmed with @elin-moco 
1. We only need to record the first fetch when the app is launched. 
2. We only need to record the ping for new users only (in case data mixed up)

