### PR TITLE
Fix download list is duplicated when leave app and reenter app.

### DIFF
--- a/app/src/main/java/org/mozilla/rocket/download/DownloadInfoViewModel.kt
+++ b/app/src/main/java/org/mozilla/rocket/download/DownloadInfoViewModel.kt
@@ -74,14 +74,20 @@ class DownloadInfoViewModel(private val repository: DownloadInfoRepository) : Vi
     }
 
     fun loadMore(init: Boolean) {
+        // Once the "Don't keep activity" in developer settings is enabled, loadMore is called twice continuously
+        // due to DownloadFragment is created twice. So we set isLoading immediately to prevent duplicate calls here.
+        if (isLoading) {
+            return
+        }
+        isLoading = true
         if (init) {
-            isLoading = false
             isLastPage = false
             isOpening = false
             itemCount = 0
             downloadInfoPack.list.clear()
         }
-        if (isLastPage || isLoading) {
+        if (isLastPage) {
+            isLoading = false
             return
         }
         repository.loadData(itemCount, PAGE_SIZE, object : DownloadInfoRepository.OnQueryListCompleteListener {
@@ -98,7 +104,6 @@ class DownloadInfoViewModel(private val repository: DownloadInfoRepository) : Vi
                 }
             }
         })
-        isLoading = true
     }
 
     fun cancel(rowId: Long) {


### PR DESCRIPTION
- Don't keep activities in developer settings is on.
- DownloadFragment is created twice at this moment.