### PR TITLE
Support Remote Config on "Share Dialog" closes #3088

### DIFF
--- a/app/src/main/java/org/mozilla/focus/utils/AppConfigWrapper.java
+++ b/app/src/main/java/org/mozilla/focus/utils/AppConfigWrapper.java
@@ -95,4 +95,18 @@ public class AppConfigWrapper {
     public static String getFirstLaunchNotificationiMessage(Context context) {
         return FirebaseHelper.getRcString(context, FirebaseHelper.FIRST_LAUNCH_NOTIFICATION_MESSAGE);
     }
+
+    static String getShareAppDialogTitle(Context context) {
+        return FirebaseHelper.getRcString(context, FirebaseHelper.STR_SHARE_APP_DIALOG_TITLE);
+    }
+
+    // Only this field supports prettify
+    static String getShareAppDialogContent(Context context) {
+        final String rcString = FirebaseHelper.getRcString(context, FirebaseHelper.STR_SHARE_APP_DIALOG_CONTENT);
+        return FirebaseHelper.prettify(rcString);
+    }
+
+    static String getShareAppMessage(Context context) {
+        return FirebaseHelper.getRcString(context, FirebaseHelper.STR_SHARE_APP_DIALOG_MSG);
+    }
 }

--- a/app/src/main/java/org/mozilla/focus/utils/DialogUtils.java
+++ b/app/src/main/java/org/mozilla/focus/utils/DialogUtils.java
@@ -21,7 +21,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
-
 import org.mozilla.focus.R;
 import org.mozilla.focus.activity.MainActivity;
 import org.mozilla.focus.activity.SettingsActivity;
@@ -121,10 +120,10 @@ public class DialogUtils {
         dialog.setOnCancelListener(dialogInterface -> telemetryShareApp(context, TelemetryWrapper.Value.DISMISS));
 
         View dialogView = LayoutInflater.from(context).inflate(R.layout.layout_share_app_dialog, null);
-
-        final TextView textView = dialogView.findViewById(R.id.share_app_dialog_textview_title);
-        textView.setText(context.getString(R.string.share_app_dialog_text_title, context.getString(R.string.app_name)));
-
+        dialogView.<TextView>findViewById(R.id.share_app_dialog_textview_title).setText(
+                AppConfigWrapper.getShareAppDialogTitle(context));
+        dialogView.<TextView>findViewById(R.id.share_app_dialog_textview_content).setText(
+                AppConfigWrapper.getShareAppDialogContent(context));
         dialogView.findViewById(R.id.dialog_share_app_btn_close).setOnClickListener(v -> {
             dialog.dismiss();
             telemetryShareApp(context, TelemetryWrapper.Value.DISMISS);
@@ -133,7 +132,7 @@ public class DialogUtils {
             Intent sendIntent = new Intent(Intent.ACTION_SEND);
             sendIntent.setType("text/plain");
             sendIntent.putExtra(Intent.EXTRA_SUBJECT, context.getString(R.string.app_name));
-            sendIntent.putExtra(Intent.EXTRA_TEXT, context.getString(R.string.share_app_promotion_text, context.getString(R.string.app_name), context.getString(R.string.share_app_google_play_url), context.getString(R.string.mozilla)));
+            sendIntent.putExtra(Intent.EXTRA_TEXT, AppConfigWrapper.getShareAppMessage(context));
             context.startActivity(Intent.createChooser(sendIntent, null));
             dialog.dismiss();
             telemetryShareApp(context, TelemetryWrapper.Value.SHARE);

--- a/app/src/main/java/org/mozilla/focus/utils/FirebaseHelper.java
+++ b/app/src/main/java/org/mozilla/focus/utils/FirebaseHelper.java
@@ -13,7 +13,6 @@ import android.os.StrictMode;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
-import android.support.annotation.WorkerThread;
 import android.support.v4.content.LocalBroadcastManager;
 import android.util.Log;
 
@@ -68,6 +67,9 @@ final public class FirebaseHelper extends FirebaseWrapper {
     private static final String FIREBASE_API_KEY = "google_api_key";
     private static final String FIREBASE_PROJECT_ID = "project_id";
 
+    static final String STR_SHARE_APP_DIALOG_TITLE = "str_share_app_dialog_title";
+    static final String STR_SHARE_APP_DIALOG_CONTENT = "str_share_app_dialog_content";
+    static final String STR_SHARE_APP_DIALOG_MSG = "str_share_app_dialog_msg";
 
     private HashMap<String, Object> remoteConfigDefault;
     private static boolean changing = false;
@@ -276,6 +278,15 @@ final public class FirebaseHelper extends FirebaseWrapper {
             map.put(FirebaseHelper.RATE_APP_DIALOG_TEXT_POSITIVE, context.getString(R.string.rate_app_dialog_btn_go_rate));
             map.put(FirebaseHelper.RATE_APP_DIALOG_TEXT_NEGATIVE, context.getString(R.string.rate_app_dialog_btn_feedback));
             map.put(FirebaseHelper.FIRST_LAUNCH_NOTIFICATION_MESSAGE, context.getString(R.string.preference_default_browser) + "?\uD83D\uDE0A");
+            // Share App
+            map.put(FirebaseHelper.STR_SHARE_APP_DIALOG_TITLE, context.getString(R.string.share_app_dialog_text_title,
+                    context.getString(R.string.app_name)));
+            map.put(FirebaseHelper.STR_SHARE_APP_DIALOG_CONTENT, context.getString(R.string.share_app_dialog_text_content));
+            final String shareAppDialogMsg = context.getString(R.string.share_app_promotion_text,
+                    context.getString(R.string.app_name), context.getString(R.string.share_app_google_play_url),
+                    context.getString(R.string.mozilla));
+            map.put(FirebaseHelper.STR_SHARE_APP_DIALOG_MSG, shareAppDialogMsg);
+
         }
         map.put(FirebaseHelper.RATE_APP_DIALOG_THRESHOLD, DialogUtils.APP_CREATE_THRESHOLD_FOR_RATE_DIALOG);
         map.put(FirebaseHelper.RATE_APP_NOTIFICATION_THRESHOLD, DialogUtils.APP_CREATE_THRESHOLD_FOR_RATE_NOTIFICATION);

--- a/app/src/main/res/layout/layout_share_app_dialog.xml
+++ b/app/src/main/res/layout/layout_share_app_dialog.xml
@@ -41,6 +41,7 @@
         android:textSize="20sp" />
 
     <TextView
+        android:id="@+id/share_app_dialog_textview_content"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginLeft="30dp"

--- a/firebase/src/firebase/java/org/mozilla/focus/utils/FirebaseWrapper.java
+++ b/firebase/src/firebase/java/org/mozilla/focus/utils/FirebaseWrapper.java
@@ -40,6 +40,7 @@ abstract class FirebaseWrapper {
     private static final boolean FIREBASE_BOOLEAN_DEFAULT = false;
     private static final long FIREBASE_LONG_DEFAULT = 0L;
     private static final String FIREBASE_STRING_DEFAULT = "";
+    private static final String NEWLINE_PLACE_HOLDER = "<BR>";
 
     // Instance of FirebaseWrapper that provides default values
     private static FirebaseWrapper instance;
@@ -97,6 +98,10 @@ abstract class FirebaseWrapper {
         }
         throwGetValueException("getRcString");
         return FIREBASE_STRING_DEFAULT;
+    }
+
+    static String prettify(@NonNull String string) {
+        return string.replace(NEWLINE_PLACE_HOLDER, "\n");
     }
 
     static long getRcLong(Context context, String key) {

--- a/firebase/src/firebase_no_op/java/org/mozilla/focus/utils/FirebaseWrapper.java
+++ b/firebase/src/firebase_no_op/java/org/mozilla/focus/utils/FirebaseWrapper.java
@@ -19,6 +19,7 @@ abstract class FirebaseWrapper {
     private static final boolean FIREBASE_BOOLEAN_DEFAULT = false;
     private static final long FIREBASE_LONG_DEFAULT = 0L;
     private static final String FIREBASE_STRING_DEFAULT = "";
+    private static final String NEWLINE_PLACE_HOLDER = "<BR>";
 
     // Instance of FirebaseWrapper that provides default values
     private static FirebaseWrapper instance;
@@ -38,6 +39,10 @@ abstract class FirebaseWrapper {
             return (Long) value;
         }
         return FIREBASE_LONG_DEFAULT;
+    }
+
+    static String prettify(String string) {
+        return string.replace(NEWLINE_PLACE_HOLDER, "\n");
     }
 
     // get Remote Config string


### PR DESCRIPTION
I can't find a method to add a new line character in Firebase remote config.
After discussing with @elin-moco 
we'll use `<BR>` in Firebase console  Remote Config setting and replace it with `\n` 
Developers should work with marketing team if they want to do this replacement in the code base.