### PR TITLE
Remove flaky with annotation

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,7 +24,7 @@ android {
         } else {
             // general UI test, using notAnnotation to filter out auto screenshot classes
             testInstrumentationRunner "org.mozilla.focus.test.runner.CustomTestRunner"
-            testInstrumentationRunnerArguments clearPackageData: 'true', notAnnotation: 'org.mozilla.focus.annotation.ScreengrabOnly'
+            testInstrumentationRunnerArguments clearPackageData: 'true', notAnnotation: 'org.mozilla.focus.annotation.ScreengrabOnly,android.support.test.filters.FlakyTest'
         }
         testInstrumentationRunnerArgument 'disableAnalytics', 'true'
 

--- a/app/src/androidTest/java/org/mozilla/focus/activity/ChangeLanguageTest.java
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/ChangeLanguageTest.java
@@ -5,6 +5,7 @@ import android.content.Intent;
 import android.content.res.Resources;
 import android.preference.Preference;
 import android.support.annotation.NonNull;
+import android.support.test.filters.FlakyTest;
 import android.support.test.rule.ActivityTestRule;
 import android.support.test.uiautomator.UiDevice;
 import android.support.test.uiautomator.UiObject;
@@ -33,6 +34,7 @@ import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.core.Is.is;
 
+@FlakyTest
 public class ChangeLanguageTest {
 
     // This is the lang name of Android system. We hard code it here so it will only fits emulator

--- a/app/src/androidTest/java/org/mozilla/focus/activity/ChangeLanguageTest.java
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/ChangeLanguageTest.java
@@ -13,7 +13,6 @@ import android.support.test.uiautomator.UiScrollable;
 import android.support.test.uiautomator.UiSelector;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mozilla.focus.R;
@@ -34,7 +33,6 @@ import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.core.Is.is;
 
-@Ignore
 public class ChangeLanguageTest {
 
     // This is the lang name of Android system. We hard code it here so it will only fits emulator

--- a/app/src/androidTest/java/org/mozilla/focus/activity/DefaultBrowserTest.java
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/DefaultBrowserTest.java
@@ -153,6 +153,7 @@ public class DefaultBrowserTest {
      * 5. Check it correctly set default browser to Firefox Lite
      */
     @Test
+    @SdkSuppress(minSdkVersion = 24, maxSdkVersion = 25)
     public void changeDefaultBrowser_whenNoDefault() {
 
         mainActivity.launchActivity(new Intent());

--- a/app/src/androidTest/java/org/mozilla/focus/activity/DefaultBrowserTest.java
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/DefaultBrowserTest.java
@@ -38,7 +38,7 @@ import static org.hamcrest.core.Is.is;
 
 // Only device with API>=24 can set default browser via system settings
 @RunWith(AndroidJUnit4.class)
-@SdkSuppress(minSdkVersion = 24, maxSdkVersion = 27)
+@SdkSuppress(minSdkVersion = 24, maxSdkVersion = 25)
 public class DefaultBrowserTest {
 
     // This is the title of Android system setting. We hard code it here so it will only fits emulator

--- a/app/src/androidTest/java/org/mozilla/focus/activity/HomeTest.java
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/HomeTest.java
@@ -12,6 +12,7 @@ import android.support.test.espresso.IdlingRegistry;
 import android.support.test.espresso.action.Tap;
 import android.support.test.espresso.contrib.RecyclerViewActions;
 import android.support.test.espresso.matcher.ViewMatchers;
+import android.support.test.filters.FlakyTest;
 import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
 import android.util.DisplayMetrics;
@@ -140,6 +141,7 @@ public class HomeTest {
      * 6. Tap on blank space above menu or
      * 7. Check menu panel not exist
      */
+    @FlakyTest
     @Test
     public void dismissMenu() {
         activityRule.launchActivity(new Intent());

--- a/app/src/androidTest/java/org/mozilla/focus/activity/OnBoardingTest.java
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/OnBoardingTest.java
@@ -9,6 +9,7 @@ import android.content.Intent;
 import android.support.annotation.Keep;
 import android.support.test.espresso.Espresso;
 import android.support.test.espresso.IdlingRegistry;
+import android.support.test.filters.FlakyTest;
 import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
 
@@ -59,6 +60,7 @@ public class OnBoardingTest {
      * 4. open menu
      * 5. check turbo mode is selected
      */
+    @FlakyTest
     @Test
     public void turnOnTurboModeDuringOnBoarding_turboModeIsOnInMenu() {
 

--- a/app/src/androidTest/java/org/mozilla/focus/test/runner/CustomTestRunner.java
+++ b/app/src/androidTest/java/org/mozilla/focus/test/runner/CustomTestRunner.java
@@ -19,7 +19,7 @@ public class CustomTestRunner extends AndroidJUnitRunner {
         arguments.putString("disableAnalytics", "true");
         arguments.putString("clearPackageData", "true");
         // Using notAnnotation to exclude auto screenshot classes when running UI test.
-        arguments.putString("notAnnotation", "org.mozilla.focus.annotation.ScreengrabOnly");
+        arguments.putString("notAnnotation", "org.mozilla.focus.annotation.ScreengrabOnly,android.support.test.filters.FlakyTest");
 
         super.onCreate(arguments);
     }


### PR DESCRIPTION
Code Change
1.  mark `turnOnTurboModeDuringOnBoarding_turboModeIsOnInMenu` &`dismissMenu` & `changeDisplayLang` to flakyTest 
2. add @FlakyTest  to notAnnotation on test runner so that it won't run flaky test on CI
3. `DefaultBrowserTest` should only run on API 24,25 (7.0,7.1.1) as the system behavior on API 23, 26 is different from API 24,25 . 

CI change
1. After this PR merge I will config CI to run on emualtors `Low-resolution MDPI phone API 23`, `Low-resolution MDPI phone API 24`,`Low-resolution MDPI phone API 26`, instead of  Nexus 5X series, API so that it will have less issues, Ex:  https://github.com/mozilla-tw/FirefoxLite/issues/3267
2. There are 3 sequentially successful build after using `Low-resolution MDPI phone` 
Build Ex: [10585](https://app.bitrise.io/build/a64a9490235ea0e9), [10586](https://app.bitrise.io/build/351d32cf4efab6dd) [10587](https://app.bitrise.io/build/3315c6df2abb436e)