### PR TITLE
Closes #3344 - Percentage changed to bytes downloaded/Total bytes

### DIFF
--- a/app/src/main/java/org/mozilla/focus/widget/DownloadListAdapter.java
+++ b/app/src/main/java/org/mozilla/focus/widget/DownloadListAdapter.java
@@ -113,7 +113,9 @@ public class DownloadListAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
                 final int progress = (int) (100 * downloadInfo.getSizeSoFar() / downloadInfo.getSizeTotal());
                 holder.progressBar.setProgress(progress);
                 holder.progressBar.setVisibility(View.VISIBLE);
-                subtitle = progress + "%";
+                Double downloadedBytes = (downloadInfo.getSizeSoFar() / 1024 / 1024);
+                Double totalBytes = (downloadInfo.getSizeTotal() / 1024 / 1024);
+                subtitle = downloadedBytes.shortValue() + "MB" + "/" + totalBytes.shortValue() + "MB";
                 holder.action.setImageLevel(ACTION_CANCEL);
             } else {
                 subtitle = statusConvertStr(downloadInfo.getStatus());


### PR DESCRIPTION

Issue

#3344 

Description

The percentage  completed indication below the download bar is changed to number of bytes downloaded/ total bytes to give the users a better experience and it can be useful to some of the users who want to efficiently use their data.

Screenshot 

![fraction](https://user-images.githubusercontent.com/22556185/55507881-53964f00-5676-11e9-9f34-43bf7b05da59.png)


