### PR TITLE
Issue #3452 - Perform WebSearch if there's pending on-boarding

### DIFF
--- a/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
+++ b/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
@@ -327,11 +327,7 @@ public class MainActivity extends BaseActivity implements FragmentListener,
     @Override
     protected void onResumeFragments() {
         super.onResumeFragments();
-
-        if (pendingUrl != null && !Settings.getInstance(this).shouldShowFirstrun()) {
-            // We have received an URL in onNewIntent(). Let's load it now.
-            // Unless we're trying to show the firstrun screen, in which case we leave it pending until
-            // firstrun is dismissed.
+        if (pendingUrl != null) {
             final SafeIntent intent = new SafeIntent(getIntent());
             boolean openInNewTab = intent.getBooleanExtra(IntentUtils.EXTRA_OPEN_NEW_TAB, true);
             this.screenNavigator.showBrowserScreen(pendingUrl, openInNewTab, true);


### PR DESCRIPTION
This PR work around the issue when there's a pending on-boarding, we still process web-search.

But actually, this is about the definition of a pending URL.

A pending URL means we want to load a URL after "some action"

Previously, this "action" is `addFirstRun()` . but not we allow the user loading the web page directly (confirmed with @Jacklin-ux ). Due to the user may already use the app, and the remote config comes late (a.k.a pending onboarding).

Do we still need this `pendingUrl` ?  Let's track the work in #3454