### PR TITLE
Issue #3477 - Change Youtube to YouTube on Top Sites

### DIFF
--- a/app/src/main/res/raw-mcc404/topsites.json
+++ b/app/src/main/res/raw-mcc404/topsites.json
@@ -2,7 +2,7 @@
   {
     "id": -1,
     "url": "https://m.youtube.com/",
-    "title": "Youtube",
+    "title": "YouTube",
     "favicon": "ic_youtube.png",
     "viewCount": 20
   },

--- a/app/src/main/res/raw-mcc405/topsites.json
+++ b/app/src/main/res/raw-mcc405/topsites.json
@@ -2,7 +2,7 @@
   {
     "id": -1,
     "url": "https://m.youtube.com/",
-    "title": "Youtube",
+    "title": "YouTube",
     "favicon": "ic_youtube.png",
     "viewCount": 20
   },

--- a/app/src/main/res/raw-mcc510/topsites.json
+++ b/app/src/main/res/raw-mcc510/topsites.json
@@ -9,7 +9,7 @@
   {
     "id": -2,
     "url": "https://m.youtube.com/",
-    "title": "Youtube",
+    "title": "YouTube",
     "favicon": "ic_youtube.png",
     "viewCount": 14
   },

--- a/app/src/main/res/raw-mcc515/topsites.json
+++ b/app/src/main/res/raw-mcc515/topsites.json
@@ -2,7 +2,7 @@
   {
     "id": -1,
     "url": "https://m.youtube.com/",
-    "title": "Youtube",
+    "title": "YouTube",
     "favicon": "ic_youtube.png",
     "viewCount": 20
   },

--- a/app/src/main/res/raw-mcc520/topsites.json
+++ b/app/src/main/res/raw-mcc520/topsites.json
@@ -2,7 +2,7 @@
   {
     "id": -1,
     "url": "https://m.youtube.com/",
-    "title": "Youtube",
+    "title": "YouTube",
     "favicon": "ic_youtube.png",
     "viewCount": 20
   },

--- a/app/src/main/res/raw/topsites.json
+++ b/app/src/main/res/raw/topsites.json
@@ -2,7 +2,7 @@
   {
     "id": -1,
     "url": "https://m.youtube.com/",
-    "title": "Youtube",
+    "title": "YouTube",
     "favicon": "ic_youtube.png",
     "viewCount": 20
   },


### PR DESCRIPTION
Changed `youtube` to `YouTube` in all the `topsites.json` files.