### PR TITLE
Issue #3534 - Fix the news source settings is not shown when life feed is enabled

### DIFF
--- a/app/src/main/java/org/mozilla/focus/settings/SettingsFragment.java
+++ b/app/src/main/java/org/mozilla/focus/settings/SettingsFragment.java
@@ -45,7 +45,7 @@ public class SettingsFragment extends PreferenceFragment implements SharedPrefer
             Preference category = findPreference(getString(R.string.pref_key_category_development));
             rootPreferences.removePreference(category);
         }
-        if (!NewFeatureNotice.getInstance(getActivity()).isNewsEnabled()) {
+        if (!AppConfigWrapper.isLifeFeedEnabled()) {
             Preference category = findPreference(getString(R.string.pref_s_news));
             rootPreferences.removePreference(category);
         }


### PR DESCRIPTION
Close #3534 