### PR TITLE
Correct random bound in NewsSourceManager 1 -> 2

### DIFF
--- a/app/src/main/java/org/mozilla/rocket/content/NewsSourceManager.java
+++ b/app/src/main/java/org/mozilla/rocket/content/NewsSourceManager.java
@@ -40,7 +40,7 @@ public class NewsSourceManager {
             final Settings settings = Settings.getInstance(context);
             final String source = settings.getNewsSource();
             if (TextUtils.isEmpty(source)) {
-                if (new Random().nextInt(1) % 2 == 0) {
+                if (new Random().nextInt(2) % 2 == 0) {
                     newsSource = NEWS_DB;
                 } else {
                     newsSource = NEWS_NP;


### PR DESCRIPTION
Fixes #3492 (The branch name `issues/3545` is incorrect)