### PR TITLE
Fix incorrect home layout issue happen after coming back from browser screen in landscape

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -256,8 +256,7 @@
         <activity
             android:name="org.mozilla.rocket.nightmode.AdjustBrightnessDialog"
             android:theme="@style/TransparentTheme"
-            android:exported="false"
-            android:screenOrientation="portrait" />
+            android:exported="false" />
     </application>
 
 </manifest>

--- a/app/src/main/res/layout-w600dp-land/fragment_homescreen.xml
+++ b/app/src/main/res/layout-w600dp-land/fragment_homescreen.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<org.mozilla.focus.widget.SwipeMotionLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/home_container">
+
+    <org.mozilla.focus.home.HomeScreenBackground
+        android:id="@+id/home_background"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@drawable/bg_homescreen_color"
+        android:scaleType="fitStart" />
+
+    <ImageView
+        android:id="@+id/home_wifi_vpn_survey"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="17dp"
+        android:layout_marginTop="21dp"
+        android:padding="15dp"
+        android:tint="@android:color/white"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        android:src="@drawable/vpn" />
+
+    <include layout="@layout/fragment_homescreen_item_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/home_fragment_fake_input"/>
+
+    <android.support.v7.widget.RecyclerView
+        android:id="@+id/banner"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginBottom="36dp"
+        app:layout_constraintDimensionRatio="H,2:1"
+        app:layout_constraintBottom_toTopOf="@id/home_fragment_fake_input"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
+
+    <include
+        android:id="@+id/home_fragment_fake_input"
+        layout="@layout/fragment_homescreen_item_fake_input"
+        android:layout_width="@dimen/fake_input_width"
+        android:layout_height="@dimen/fake_input_height"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <include layout="@layout/fragment_homescreen_item_recyclerview"
+        android:id="@+id/main_list"
+        android:layout_width="296dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/home_fragment_fake_input"
+        android:layout_marginTop="@dimen/home_padding_url_bar_to_top_sites"/>
+
+    <include layout="@layout/fragment_homescreen_item_menu_button"/>
+
+</org.mozilla.focus.widget.SwipeMotionLayout>

--- a/app/src/main/res/layout-w600dp-land/fragment_homescreen_content.xml
+++ b/app/src/main/res/layout-w600dp-land/fragment_homescreen_content.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<org.mozilla.focus.widget.SwipeMotionLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/home_container">
+
+    <org.mozilla.focus.home.HomeScreenBackground
+        android:id="@+id/home_background"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@drawable/bg_homescreen_color"
+        android:scaleType="fitStart" />
+
+    <ImageView
+        android:id="@+id/home_wifi_vpn_survey"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="17dp"
+        android:layout_marginTop="21dp"
+        android:padding="15dp"
+        android:tint="@android:color/white"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        android:src="@drawable/vpn" />
+
+    <include layout="@layout/fragment_homescreen_item_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/home_fragment_fake_input"/>
+
+    <android.support.v7.widget.RecyclerView
+        android:id="@+id/banner"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginBottom="36dp"
+        app:layout_constraintDimensionRatio="H,2:1"
+        app:layout_constraintBottom_toTopOf="@id/home_fragment_fake_input"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
+
+    <include
+        android:id="@+id/home_fragment_fake_input"
+        layout="@layout/fragment_homescreen_item_fake_input"
+        android:layout_width="@dimen/fake_input_width"
+        android:layout_height="@dimen/fake_input_height"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <include layout="@layout/fragment_homescreen_item_arrow"/>
+
+    <include layout="@layout/fragment_homescreen_item_recyclerview"
+        android:id="@+id/main_list"
+        android:layout_width="296dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/home_fragment_fake_input"
+        android:layout_marginTop="@dimen/home_padding_url_bar_to_top_sites"/>
+
+    <include layout="@layout/fragment_homescreen_item_menu_button"/>
+
+    <include layout="@layout/content_portal"/>
+
+
+
+</org.mozilla.focus.widget.SwipeMotionLayout>


### PR DESCRIPTION
Originally, we use layout-h600dp to distinguish between longer and shorter devices, so we can inflate customized layout for shorter device. However, after supporting landscape mode, when the user goes back to home from browser fragment in landscape mode, the width and height of the screen is exchanged, home fragment will mistakenly resolve its layout to the shorter version.

Solution
For now, I duplicate layout-h600dp/fragment_homescreen to a new layout-w600dp-land folder, so no matter what the orientation is during the rotation, home fragment can resolve to the same correct layout file.

This is just a workaround. To better solve this issue, maybe we should create a single layout file that adapts to both short and long devices.