### PR TITLE
Fix incorrect find-in-page bottom padding after keyboard shows up

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
@@ -151,6 +151,9 @@ public class BrowserFragment extends LocaleAwareFragment implements View.OnClick
     private Dialog webContextMenu;
     private ThemedRelativeLayout bottomMenuContainer;
 
+    private View mainContent;
+    private int mainContentBottomMargin;
+
     //GeoLocationPermission
     private String geolocationOrigin;
     private GeolocationPermissions.Callback geolocationCallback;
@@ -407,6 +410,12 @@ public class BrowserFragment extends LocaleAwareFragment implements View.OnClick
         videoContainer = (ViewGroup) view.findViewById(R.id.video_container);
         browserContainer = view.findViewById(R.id.browser_container);
 
+        mainContent = view.findViewById(R.id.main_content);
+        ViewGroup.MarginLayoutParams params = getMarginLayoutParams(mainContent);
+        if (params != null) {
+            mainContentBottomMargin = params.bottomMargin;
+        }
+
         urlView = view.findViewById(R.id.display_url);
 
         backgroundView = view.findViewById(R.id.background);
@@ -547,12 +556,30 @@ public class BrowserFragment extends LocaleAwareFragment implements View.OnClick
             toolbarRoot.setVisibility(View.GONE);
             bottomMenuContainer.setVisibility(View.GONE);
             bottomMenuDivider.setVisibility(View.GONE);
+            updateMainContentBottomMargin(0);
             onLandscapeModeStart();
         } else {
             toolbarRoot.setVisibility(View.VISIBLE);
             bottomMenuContainer.setVisibility(View.VISIBLE);
             bottomMenuDivider.setVisibility(View.VISIBLE);
+            updateMainContentBottomMargin(mainContentBottomMargin);
             onLandscapeModeFinish();
+        }
+    }
+
+    @Nullable
+    private ViewGroup.MarginLayoutParams getMarginLayoutParams(View view) {
+        ViewGroup.LayoutParams params = view.getLayoutParams();
+        if (params instanceof ViewGroup.MarginLayoutParams) {
+            return (ViewGroup.MarginLayoutParams) params;
+        }
+        return null;
+    }
+
+    private void updateMainContentBottomMargin(int marginBottom) {
+        ViewGroup.MarginLayoutParams params = getMarginLayoutParams(mainContent);
+        if (params != null) {
+            params.bottomMargin = marginBottom;
         }
     }
 

--- a/app/src/main/res/layout/fragment_browser.xml
+++ b/app/src/main/res/layout/fragment_browser.xml
@@ -9,23 +9,10 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <include
-        android:id="@+id/browser_menu_container"
-        layout="@layout/fragment_browser_item_menu_button" />
-
-    <org.mozilla.rocket.nightmode.themed.ThemedView
-        android:id="@+id/bottom_menu_divider"
-        android:layout_width="match_parent"
-        android:layout_height="1dp"
-        android:layout_above="@id/browser_menu_container"
-        android:background="@drawable/browser_menu_divider"
-        tools:background="#FF0000" />
-
     <org.mozilla.rocket.nightmode.themed.ThemedLinearLayout
         android:id="@+id/browser_container"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_above="@id/bottom_menu_divider"
         android:background="@drawable/browser_background"
         android:orientation="vertical">
 
@@ -85,7 +72,8 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:clipChildren="false"
-            android:orientation="vertical">
+            android:orientation="vertical"
+            android:layout_marginBottom="@dimen/fixed_menu_height">
 
             <LinearLayout
                 android:layout_width="match_parent"
@@ -106,6 +94,18 @@
 
         </org.mozilla.focus.widget.ResizableKeyboardLayout>
     </org.mozilla.rocket.nightmode.themed.ThemedLinearLayout>
+
+    <include
+        android:id="@+id/browser_menu_container"
+        layout="@layout/fragment_browser_item_menu_button" />
+
+    <org.mozilla.rocket.nightmode.themed.ThemedView
+        android:id="@+id/bottom_menu_divider"
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:layout_above="@+id/browser_menu_container"
+        android:background="@drawable/browser_menu_divider"
+        tools:background="#FF0000" />
 
     <FrameLayout
         android:id="@+id/video_container"


### PR DESCRIPTION
Close #3580 

in https://github.com/mozilla-tw/FirefoxLite/pull/3563/commits/015dfa62da55e695a4a2b365d5488ca8387d6c4e, I remove the marginBottom of the ResizableKeyboardLayout, and use layout_above attribute to build the relationship between bottom bar and main browser content. However, this marginBottom is a critical attribute that will affect how ResizableKeyboardLayout behaves when keyboard is shown.

To fix this issue, I add the marginBottom attribute back, and assign it different values each time the screen is rotated.