### PR TITLE
Fix the crash when no bookmark button on the menu bottom bar

### DIFF
--- a/app/src/androidTest/java/org/mozilla/focus/Inject.java
+++ b/app/src/androidTest/java/org/mozilla/focus/Inject.java
@@ -17,7 +17,9 @@ import android.support.v4.app.FragmentActivity;
 import android.view.View;
 import android.view.animation.Animation;
 
+import org.mozilla.focus.persistence.BookmarksDatabase;
 import org.mozilla.focus.persistence.TabsDatabase;
+import org.mozilla.focus.repository.BookmarkRepository;
 import org.mozilla.focus.utils.AppConstants;
 import org.mozilla.focus.utils.RemoteConfigConstants;
 import org.mozilla.focus.utils.Settings;
@@ -150,7 +152,8 @@ public class Inject {
 
     public static ChromeViewModel obtainChromeViewModel(FragmentActivity activity) {
         Settings settings = Settings.getInstance(activity);
-        ChromeViewModelFactory factory = ChromeViewModelFactory.getInstance(settings);
+        BookmarkRepository bookmarkRepo = BookmarkRepository.getInstance(BookmarksDatabase.getInstance(activity));
+        ChromeViewModelFactory factory = ChromeViewModelFactory.getInstance(settings, bookmarkRepo);
         return ViewModelProviders.of(activity, factory).get(ChromeViewModel.class);
     }
 

--- a/app/src/main/java/org/mozilla/focus/Inject.java
+++ b/app/src/main/java/org/mozilla/focus/Inject.java
@@ -17,7 +17,9 @@ import android.view.View;
 import android.view.animation.Animation;
 
 import org.mozilla.focus.home.HomeFragment;
+import org.mozilla.focus.persistence.BookmarksDatabase;
 import org.mozilla.focus.persistence.TabsDatabase;
+import org.mozilla.focus.repository.BookmarkRepository;
 import org.mozilla.focus.utils.AppConstants;
 import org.mozilla.focus.utils.RemoteConfigConstants;
 import org.mozilla.focus.utils.Settings;
@@ -132,7 +134,8 @@ public class Inject {
 
     public static ChromeViewModel obtainChromeViewModel(FragmentActivity activity) {
         Settings settings = Settings.getInstance(activity);
-        ChromeViewModelFactory factory = ChromeViewModelFactory.getInstance(settings);
+        BookmarkRepository bookmarkRepo = BookmarkRepository.getInstance(BookmarksDatabase.getInstance(activity));
+        ChromeViewModelFactory factory = ChromeViewModelFactory.getInstance(settings, bookmarkRepo);
         return ViewModelProviders.of(activity, factory).get(ChromeViewModel.class);
     }
 

--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
@@ -1288,6 +1288,7 @@ public class BrowserFragment extends LocaleAwareFragment implements ScreenNaviga
 
         @Override
         public void onUrlChanged(@NonNull Session session, @Nullable String url) {
+            chromeViewModel.onFocusedUrlChanged(url);
             if (!isForegroundSession(session)) {
                 return;
             }
@@ -1536,6 +1537,7 @@ public class BrowserFragment extends LocaleAwareFragment implements ScreenNaviga
 
         @Override
         public void onFocusChanged(@Nullable final Session tab, SessionManager.Factor factor) {
+            chromeViewModel.onFocusedUrlChanged(tab != null ? tab.getUrl() : null);
             if (tab == null) {
                 if (factor == SessionManager.Factor.FACTOR_NO_FOCUS && !isStartedFromExternalApp()) {
                     ScreenNavigator.get(getContext()).popToHomeScreen(true);

--- a/app/src/main/java/org/mozilla/rocket/chrome/ChromeViewModelFactory.kt
+++ b/app/src/main/java/org/mozilla/rocket/chrome/ChromeViewModelFactory.kt
@@ -2,14 +2,18 @@ package org.mozilla.rocket.chrome
 
 import android.arch.lifecycle.ViewModel
 import android.arch.lifecycle.ViewModelProvider
+import org.mozilla.focus.repository.BookmarkRepository
 import org.mozilla.focus.utils.Settings
 
-class ChromeViewModelFactory private constructor(private val settings: Settings) : ViewModelProvider.NewInstanceFactory() {
+class ChromeViewModelFactory private constructor(
+    private val settings: Settings,
+    private val bookmarkRepo: BookmarkRepository
+) : ViewModelProvider.NewInstanceFactory() {
 
     @Suppress("UNCHECKED_CAST")
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         if (modelClass.isAssignableFrom(ChromeViewModel::class.java)) {
-            return ChromeViewModel(settings) as T
+            return ChromeViewModel(settings, bookmarkRepo) as T
         }
         throw IllegalArgumentException("Unknown ViewModel class: " + modelClass.name)
     }
@@ -19,9 +23,9 @@ class ChromeViewModelFactory private constructor(private val settings: Settings)
         @Volatile private var INSTANCE: ChromeViewModelFactory? = null
 
         @JvmStatic
-        fun getInstance(settings: Settings): ChromeViewModelFactory? =
+        fun getInstance(settings: Settings, bookmarkRepo: BookmarkRepository): ChromeViewModelFactory? =
                 INSTANCE ?: synchronized(this) {
-                    INSTANCE ?: ChromeViewModelFactory(settings).also { INSTANCE = it }
+                    INSTANCE ?: ChromeViewModelFactory(settings, bookmarkRepo).also { INSTANCE = it }
                 }
     }
 }


### PR DESCRIPTION
- Fix the crash when no bookmark button on the menu bar

Steps:
1. config the bottom bar with a bookmark button, and with no bookmark button on the menu bottom bar.
2. click bookmark button while browsing web page
3. app crash

- added `focusedSessionUrl` as a LiveData in `ChromeViewModel`