### PR TITLE
Show shortcut promotion only when leaving from private home fragment

### DIFF
--- a/app/src/main/java/org/mozilla/focus/navigation/TransactionHelper.java
+++ b/app/src/main/java/org/mozilla/focus/navigation/TransactionHelper.java
@@ -35,20 +35,17 @@ class TransactionHelper implements DefaultLifecycleObserver {
 
     TransactionHelper(@NonNull ScreenNavigator.HostActivity activity) {
         this.activity = activity;
-        this.backStackListener = new BackStackListener(this);
+        registerBackStackListener();
     }
 
     @Override
     public void onStart(@NonNull LifecycleOwner owner) {
-        this.activity.getSupportFragmentManager()
-                .addOnBackStackChangedListener(this.backStackListener = new BackStackListener(this));
+        registerBackStackListener();
     }
 
     @Override
     public void onStop(@NonNull LifecycleOwner owner) {
-        this.activity.getSupportFragmentManager()
-                .removeOnBackStackChangedListener(this.backStackListener);
-        this.backStackListener.onStop();
+        unregisterBackStackListener();
     }
 
     void showHomeScreen(boolean animated, @EntryData.EntryType int type, boolean executeImmediatly) {
@@ -232,6 +229,23 @@ class TransactionHelper implements DefaultLifecycleObserver {
 
     private void onFragmentBroughtToFront(String fragmentTag) {
         topFragmentState.setValue(fragmentTag);
+    }
+
+    private void registerBackStackListener() {
+        if (this.backStackListener == null) {
+            this.backStackListener = new BackStackListener(this);
+            this.activity.getSupportFragmentManager().addOnBackStackChangedListener(
+                    this.backStackListener);
+        }
+    }
+
+    private void unregisterBackStackListener() {
+        if (this.backStackListener != null) {
+            this.activity.getSupportFragmentManager().removeOnBackStackChangedListener(
+                    this.backStackListener);
+            this.backStackListener.onStop();
+            this.backStackListener = null;
+        }
     }
 
     private static class BackStackListener implements FragmentManager.OnBackStackChangedListener {


### PR DESCRIPTION
This PR was originally in #3627


According to the comment there:

> cnevinc 5 hours ago  Member
add a comment to explain why it's needed. since the boolean parameter is always confusing.

Now ShortcutViewModel will retrieve navigation state directly from ScreenNavigator instead of requiring the caller to pass a confusing "isHomeScreen" parameter.


And for comment: 

>  I feel like this will make the pop-up / usage much lower than we expected.

Have already confirmed with UX @Jacklin-ux, we will keep this behavior until we have more data and see if further improvement is needed.