### PR TITLE
Bring launcher home to front after creating the shortcut

### DIFF
--- a/app/src/main/java/org/mozilla/focus/utils/IntentUtils.java
+++ b/app/src/main/java/org/mozilla/focus/utils/IntentUtils.java
@@ -6,10 +6,12 @@ package org.mozilla.focus.utils;
 
 import android.app.Activity;
 import android.app.DownloadManager;
+import android.app.PendingIntent;
 import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.content.IntentSender;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.net.Uri;
@@ -266,5 +268,17 @@ public class IntentUtils {
             // In some cases, a matching Activity may not exist (according to the Android docs).
             return false;
         }
+    }
+
+    public static Intent getLauncherHomeIntent() {
+        Intent homeIntent = new Intent(Intent.ACTION_MAIN);
+        homeIntent.addCategory(Intent.CATEGORY_HOME);
+        homeIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        return homeIntent;
+    }
+
+    public static PendingIntent getLauncherHomePendingIntent(Context context) {
+        return PendingIntent.getActivity(context, 0, getLauncherHomeIntent(),
+                PendingIntent.FLAG_UPDATE_CURRENT);
     }
 }

--- a/app/src/main/java/org/mozilla/focus/utils/ShortcutUtils.java
+++ b/app/src/main/java/org/mozilla/focus/utils/ShortcutUtils.java
@@ -5,7 +5,6 @@
 package org.mozilla.focus.utils;
 
 import android.annotation.TargetApi;
-import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentSender;
@@ -58,11 +57,8 @@ public class ShortcutUtils {
                 .build();
 
         // Display home screen after add to home screen
-        final Intent showHome = new Intent(Intent.ACTION_MAIN);
-        showHome.addCategory(Intent.CATEGORY_HOME);
-        showHome.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-        final PendingIntent pendingIntent = PendingIntent.getActivity(context, 0, showHome, PendingIntent.FLAG_UPDATE_CURRENT);
-        final IntentSender intentSender = pendingIntent.getIntentSender();
+        final IntentSender intentSender = IntentUtils.getLauncherHomePendingIntent(context)
+                .getIntentSender();
 
         // Update the shortcut icon on launcher since previous one may not ready. API 26+ only.
         // TODO: find a way to update the shortcut icon for API 25 and below. Currently the only way is remove old shortcut and add again.

--- a/app/src/main/java/org/mozilla/rocket/privately/ShortcutUtils.kt
+++ b/app/src/main/java/org/mozilla/rocket/privately/ShortcutUtils.kt
@@ -12,6 +12,7 @@ import android.support.v4.content.pm.ShortcutManagerCompat
 import android.support.v4.graphics.drawable.IconCompat
 import org.mozilla.focus.R
 import org.mozilla.focus.utils.AppConstants
+import org.mozilla.focus.utils.IntentUtils
 import org.mozilla.rocket.component.LaunchIntentDispatcher
 
 class ShortcutUtils {
@@ -39,8 +40,14 @@ class ShortcutUtils {
                     .setIcon(icon)
                     .build()
 
+            // Known issue: when there is already an existing shortcut, intendSender will be called
+            // immediately when system shortcut dialog is shown. i.e. Home will be brought up, and then
+            // show the system shortcut dialog. UX currently agreed with this behavior since it's
+            // not often the user will add shortcut again.
+            val intentSender = IntentUtils.getLauncherHomePendingIntent(context).intentSender
+
             if (ShortcutManagerCompat.isRequestPinShortcutSupported(context)) {
-                ShortcutManagerCompat.requestPinShortcut(context, shortcut, null)
+                ShortcutManagerCompat.requestPinShortcut(context, shortcut, intentSender)
             }
         }
     }


### PR DESCRIPTION
This PR was originally in #3627

According to the comment:

> cnevinc 5 hours ago  • 
 Member
nit: extract this block and reuse it.

Now two new API getLauncherHomeIntent() and getLauncherHomePendingIntent() are added to IntentUtils.java