### PR TITLE
Upgrade Android Components

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -167,12 +167,12 @@ android {
         // used by Room, to test migrations
         androidTest.assets.srcDirs += files("$projectDir/schemas".toString())
     }
+}
 
-    // According to https://github.com/Kotlin/kotlinx.coroutines/issues/1064
-    // We can get rid of this once Android-Components' upgrade to 0.53.0 with coroutines 1.2.1
-    packagingOptions {
-        pickFirst 'META-INF/atomicfu.kotlin_module'
-    }
+// According to https://github.com/Kotlin/kotlinx.coroutines/issues/1064
+// We can get rid of this once Android-Components' upgrade to 0.53.0 with coroutines 1.2.1
+configurations {
+    compile.exclude group: 'org.jetbrains.kotlinx', module: 'atomicfu-common'
 }
 
 repositories {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -167,6 +167,12 @@ android {
         // used by Room, to test migrations
         androidTest.assets.srcDirs += files("$projectDir/schemas".toString())
     }
+
+    // According to https://github.com/Kotlin/kotlinx.coroutines/issues/1064
+    // We can get rid of this once Android-Components' upgrade to 0.53.0 with coroutines 1.2.1
+    packagingOptions {
+        pickFirst 'META-INF/atomicfu.kotlin_module'
+    }
 }
 
 repositories {
@@ -200,11 +206,6 @@ dependencies {
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${Versions.kotlin}"
 
-    // We didn't use CustomTabs so far. This is a build hack to force Android-Components to use
-    // same version of support library as we are. Android-Components depends on CustomTabs which
-    // version will be override by this.
-    // We can get rid of this once Android-Components' issue #404 has been resolve.
-    implementation "com.android.support:customtabs:${Versions.support}"
     implementation "com.android.support:support-v4:${Versions.support}"
     implementation "com.android.support:appcompat-v7:${Versions.support}"
     implementation "com.android.support:design:${Versions.support}"
@@ -231,6 +232,7 @@ dependencies {
     implementation "org.mozilla.components:service-telemetry:${Versions.android_components}"
     implementation "org.mozilla.components:browser-domains:${Versions.android_components}"
     implementation "org.mozilla.components:ui-autocomplete:${Versions.android_components}"
+    implementation "org.mozilla.components:lib-fetch-httpurlconnection:${Versions.android_components}"
 
     implementation "com.adjust.sdk:adjust-android:${Versions.adjust}"
     implementation "com.google.android.gms:play-services-analytics:${Versions.firebase}" // Required by Adjust

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -120,3 +120,7 @@ public static java.lang.String TABLENAME;
 ## Integrate Glide source code
 -dontwarn android.graphics.Bitmap$Config
 -dontwarn android.app.FragmentManager
+
+# According to https://github.com/Kotlin/kotlinx.coroutines/issues/1155
+# We can get rid of this once Android-Components' upgrade to 0.53.0 with coroutines 1.2.1
+-dontwarn kotlinx.atomicfu.AtomicFU

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -169,13 +169,6 @@
                 <action android:name="com.google.firebase.MESSAGING_EVENT"/>
             </intent-filter>
         </service>
-        <!-- Custom Tabs Service is currently not registering the intent-filter before its ready.
-             It should also be set to exported=true if you want to turn it on -->
-        <service
-            android:name="org.mozilla.focus.customtabs.CustomTabsService"
-            android:enabled="false"
-            android:exported="false"
-            tools:ignore="ExportedService" />
 
         <meta-data
             android:name="android.webkit.WebView.MetricsOptOut"

--- a/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
+++ b/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
@@ -15,6 +15,7 @@ import android.os.StrictMode.ThreadPolicy.Builder
 import android.preference.PreferenceManager
 import android.util.Log
 import android.webkit.PermissionRequest
+import mozilla.components.lib.fetch.httpurlconnection.HttpURLConnectionClient
 import org.mozilla.focus.BuildConfig
 import org.mozilla.focus.Inject
 import org.mozilla.focus.R
@@ -41,7 +42,7 @@ import org.mozilla.telemetry.measurement.EventsMeasurement
 import org.mozilla.telemetry.measurement.SearchesMeasurement
 import org.mozilla.telemetry.measurement.SettingsMeasurement
 import org.mozilla.telemetry.measurement.TelemetryMeasurement
-import org.mozilla.telemetry.net.HttpURLConnectionTelemetryClient
+import org.mozilla.telemetry.net.TelemetryClient
 import org.mozilla.telemetry.ping.TelemetryCorePingBuilder
 import org.mozilla.telemetry.ping.TelemetryEventPingBuilder
 import org.mozilla.telemetry.ping.TelemetryPingBuilder
@@ -331,7 +332,7 @@ object TelemetryWrapper {
 
             val serializer = JSONPingSerializer()
             val storage = FileTelemetryStorage(configuration, serializer)
-            val client = HttpURLConnectionTelemetryClient()
+            val client = TelemetryClient(HttpURLConnectionClient())
             val scheduler = JobSchedulerTelemetryScheduler()
 
             TelemetryHolder.set(

--- a/app/src/main/java/org/mozilla/rocket/privately/browse/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/rocket/privately/browse/BrowserFragment.kt
@@ -535,9 +535,9 @@ class BrowserFragment : LocaleAwareFragment(),
             val d = Download(
                     download.url,
                     download.fileName,
-                    download.userAgent!!,
+                    download.userAgent,
                     "",
-                    download.contentType!!,
+                    download.contentType,
                     download.contentLength!!,
                     false
                     )

--- a/app/src/main/res/layout/fragment_urlinput.xml
+++ b/app/src/main/res/layout/fragment_urlinput.xml
@@ -95,6 +95,14 @@
                 app:layout_constraintTop_toTopOf="@id/quick_search_recycler_view" />
         </android.support.constraint.ConstraintLayout>
 
+        <View
+            android:id="@+id/dismiss"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_above="@id/quick_search_container"
+            android:background="@color/colorUrlInputBackground"
+            android:contentDescription="@string/content_description_dismiss_input" />
+
         <org.mozilla.focus.widget.FlowLayout
             android:id="@+id/search_suggestion"
             android:layout_width="match_parent"
@@ -105,12 +113,5 @@
             tools:background="#55FF0000" />
 
     </RelativeLayout>
-
-    <View
-        android:id="@+id/dismiss"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:background="@color/colorUrlInputBackground"
-        android:contentDescription="@string/content_description_dismiss_input" />
 
 </org.mozilla.focus.widget.ResizableKeyboardLayout>

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -21,7 +21,7 @@ object Versions {
     const val findbugs = "3.0.1"
     const val lottie = "2.7.0"
     const val leakcanary = "1.6.2"
-    const val android_components = "0.27.0"
+    const val android_components = "0.51.0"
     const val adjust = "4.11.4"
     const val junit = "4.12"
     const val mockito = "2.12.0"

--- a/components/feature/tabs/build.gradle
+++ b/components/feature/tabs/build.gradle
@@ -22,3 +22,9 @@ dependencies {
 afterEvaluate {
     check.dependsOn 'findbugs', 'pmd', 'checkstyle'
 }
+
+// According to https://github.com/Kotlin/kotlinx.coroutines/issues/1064
+// We can get rid of this once Android-Components' upgrade to 0.53.0 with coroutines 1.2.1
+configurations {
+    compile.exclude group: 'org.jetbrains.kotlinx', module: 'atomicfu-common'
+}

--- a/components/feature/tabs/src/main/java/org/mozilla/rocket/tabs/TabViewEngineObserver.kt
+++ b/components/feature/tabs/src/main/java/org/mozilla/rocket/tabs/TabViewEngineObserver.kt
@@ -83,7 +83,7 @@ class TabViewEngineObserver(
 
     override fun onExternalResource(
         url: String,
-        fileName: String?,
+        fileName: String,
         contentLength: Long?,
         contentType: String?,
         cookie: String?,

--- a/components/feature/tabs/src/main/java/org/mozilla/rocket/tabs/web/Download.java
+++ b/components/feature/tabs/src/main/java/org/mozilla/rocket/tabs/web/Download.java
@@ -42,9 +42,9 @@ public class Download implements Parcelable {
 
     public Download(@NonNull String url,
                     @Nullable String name,
-                    @NonNull String userAgent,
-                    @NonNull String contentDisposition,
-                    @NonNull String mimeType,
+                    @Nullable String userAgent,
+                    @Nullable String contentDisposition,
+                    @Nullable String mimeType,
                     long contentLength,
                     boolean startFromContextMenu) {
         this.url = url;


### PR DESCRIPTION
- Upgrade Android Components to 0.51.0
- Add `lib-fetch-httpurlconnection` because `HttpURLConnectionTelemetryClient` was removed
- Modify UrlInputFragment because `DomainAutoCompleteProvider` was deprecated & OnFilterListener 2nd param was removed
- Modify UrlInputFragment layout in order to pass UI test (SearchFieldTest)