### PR TITLE
Apply the same life feed provider remote config accross different app version

### DIFF
--- a/app/src/main/java/org/mozilla/focus/utils/AppConfigWrapper.java
+++ b/app/src/main/java/org/mozilla/focus/utils/AppConfigWrapper.java
@@ -15,15 +15,18 @@ import org.mozilla.rocket.content.ecommerce.data.Coupon;
 import org.mozilla.rocket.content.ecommerce.data.CouponKey;
 import org.mozilla.rocket.content.ecommerce.data.ShoppingLink;
 import org.mozilla.rocket.content.ecommerce.data.ShoppingLinkKey;
+import org.mozilla.rocket.content.news.data.NewsProviderConfig;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class AppConfigWrapper {
     static final int SURVEY_NOTIFICATION_POST_THRESHOLD = 3;
     static final boolean PRIVATE_MODE_ENABLED_DEFAULT = true;
     static final boolean LIFE_FEED_ENABLED_DEFAULT = false;
-    static final String STR_NEWS_PROVIDERS_DEFAULT = "";
+    static final String LIFE_FEED_PROVIDERS_DEFAULT = "";
     static final String STR_E_COMMERCE_SHOPPINGLINKS_DEFAULT = "";
     static final String STR_E_COMMERCE_COUPONS_DEFAULT = "";
     static final String STR_E_COMMERCE_COUPON_BANNER_DEFAULT = "";
@@ -32,6 +35,18 @@ public class AppConfigWrapper {
     /* Disabled since v1.0.4, keep related code in case we want to enable it again in the future */
     private static final boolean SURVEY_NOTIFICATION_ENABLED = false;
     static final int DRIVE_DEFAULT_BROWSER_FROM_MENU_SETTING_THRESHOLD = 2;
+
+    /* For Newspoint, we have an new url endpoint to support category tab feature. In order to backward compatible to the legacy user,
+     * we use a different feature name as key on the Firebase remote config. So the existing config entry can be shared by different app version */
+    private static final Map<String, NewsProviderConfig> lifeFeedProviderConfigNameMapping = new HashMap<>();
+
+    static {
+        lifeFeedProviderConfigNameMapping.put("Newspoint",
+                new NewsProviderConfig(
+                        "NewspointCategory",
+                        "http://partnersnp.indiatimes.com/feed/fx/atp?channel=*&section=%s&lang=%s&curpg=%s&pp=%s&v=v1&fromtime=1551267146210"
+                ));
+    }
 
     public static long getRateAppNotificationLaunchTimeThreshold() {
         return FirebaseHelper.getFirebase().getRcLong(FirebaseHelper.RATE_APP_NOTIFICATION_THRESHOLD);
@@ -199,14 +214,14 @@ public class AppConfigWrapper {
     }
 
     public static String getNewsProviderUrl(String provider) {
-        String source = FirebaseHelper.getFirebase().getRcString(FirebaseHelper.STR_NEWS_PROVIDERS);
+        String source = FirebaseHelper.getFirebase().getRcString(FirebaseHelper.LIFE_FEED_PROVIDERS);
         String url = "";
 
         try {
             JSONArray rows = new JSONArray(source);
             for (int i = 0; i < rows.length(); i++) {
                 JSONObject row = rows.getJSONObject(i);
-                if (row.getString("name").equalsIgnoreCase(provider)) {
+                if (row.getString("name").equalsIgnoreCase(getProviderConfigName(provider))) {
                     url = row.getString("url");
                     break;
                 }
@@ -215,7 +230,17 @@ public class AppConfigWrapper {
             e.printStackTrace();
         }
 
-        return url;
+        return !url.isEmpty() ? url : getProviderDefaultUrl(provider);
+    }
+
+    private static String getProviderConfigName(String provider) {
+        NewsProviderConfig providerConfig = lifeFeedProviderConfigNameMapping.get(provider);
+        return (providerConfig != null) ? providerConfig.getConfigName() : "";
+    }
+
+    private static String getProviderDefaultUrl(String provider) {
+        NewsProviderConfig providerConfig = lifeFeedProviderConfigNameMapping.get(provider);
+        return (providerConfig != null) ? providerConfig.getDefaultUrl() : "";
     }
 
     static String getShareAppDialogTitle() {

--- a/app/src/main/java/org/mozilla/focus/utils/FirebaseHelper.java
+++ b/app/src/main/java/org/mozilla/focus/utils/FirebaseHelper.java
@@ -60,7 +60,7 @@ final public class FirebaseHelper {
     static final String FIRST_LAUNCH_TIMER_MINUTES = "first_launch_timer_minutes";
     static final String FIRST_LAUNCH_NOTIFICATION_MESSAGE = "first_launch_notification_message";
     static final String ENABLE_LIFE_FEED = "enable_life_feed";
-    static final String STR_NEWS_PROVIDERS = "str_news_providers";
+    static final String LIFE_FEED_PROVIDERS = "life_feed_providers";
     static final String STR_E_COMMERCE_SHOPPINGLINKS = "str_e_commerce_shoppinglinks";
     static final String STR_E_COMMERCE_COUPONS = "str_e_commerce_coupons";
     static final String STR_COUPON_BANNER_MANIFEST = "str_coupon_banner_manifest";
@@ -276,7 +276,7 @@ final public class FirebaseHelper {
         map.put(FirebaseHelper.VPN_RECOMMENDER_URL, FeatureSurveyViewHelper.Constants.LINK_RECOMMEND_VPN);
         map.put(FirebaseHelper.FIRST_LAUNCH_TIMER_MINUTES, FirstLaunchWorker.TIMER_DISABLED);
         map.put(FirebaseHelper.ENABLE_LIFE_FEED, AppConfigWrapper.LIFE_FEED_ENABLED_DEFAULT);
-        map.put(FirebaseHelper.STR_NEWS_PROVIDERS, AppConfigWrapper.STR_NEWS_PROVIDERS_DEFAULT);
+        map.put(FirebaseHelper.LIFE_FEED_PROVIDERS, AppConfigWrapper.LIFE_FEED_PROVIDERS_DEFAULT);
         map.put(FirebaseHelper.STR_E_COMMERCE_SHOPPINGLINKS, AppConfigWrapper.STR_E_COMMERCE_SHOPPINGLINKS_DEFAULT);
         map.put(FirebaseHelper.STR_E_COMMERCE_COUPONS, AppConfigWrapper.STR_E_COMMERCE_COUPONS_DEFAULT);
         map.put(FirebaseHelper.STR_COUPON_BANNER_MANIFEST, AppConfigWrapper.STR_E_COMMERCE_COUPON_BANNER_DEFAULT);

--- a/app/src/main/java/org/mozilla/rocket/content/news/data/NewsProviderConfig.kt
+++ b/app/src/main/java/org/mozilla/rocket/content/news/data/NewsProviderConfig.kt
@@ -1,0 +1,6 @@
+package org.mozilla.rocket.content.news.data
+
+data class NewsProviderConfig(
+    val configName: String,
+    val defaultUrl: String
+)


### PR DESCRIPTION
I've created a new remote config (str_news_providers) for the news with category API endpoint setting. However, I think it would increase the complexity to manage news API endpoints. So I try to merge the new config back to the existing one(life_feed_providers) and not to impact the legacy user who does not update to the new news enhancement. 

Related to #3665
TODO:
Delete `str_news_providers` from remote config of dev and nighly