### PR TITLE
Change Screengrab run on debug build

### DIFF
--- a/fastlane/Screengrabfile
+++ b/fastlane/Screengrabfile
@@ -1,12 +1,13 @@
 
-#locales ['en','hi','in','jv','su','th','tl','zh-TW','vi']
+#locales ['en','hi','in','jv','su','th','tl','zh-TW','vi','ta','kn','ml']
 locales ['vi','zh-TW']
 clear_previous_screenshots true
 exit_on_test_failure false
 test_instrumentation_runner  'org.mozilla.focus.test.runner.ScreenshotTestRunner'
-app_package_name 'org.mozilla.rocket.debug.firebase'
+# hardcode on debug build application_id as fastlane no customized input parameter
+app_package_name 'org.mozilla.rocket.debug.pliu'
 use_tests_in_packages ['org.mozilla.focus.screengrab']
 #use_tests_in_classes ['org.mozilla.focus.screengrab.MyShotScreenshot']
-tests_apk_path 'app/build/outputs/apk/androidTest/focusWebkit/firebase/app-focus-webkit-firebase-androidTest.apk'
-app_apk_path 'app/build/outputs/apk/focusWebkit/firebase/app-focus-webkit-firebase.apk'
+tests_apk_path 'app/build/outputs/apk/androidTest/focusWebkit/debug/app-focus-webkit-debug-androidTest.apk'
+app_apk_path 'app/build/outputs/apk/focusWebkit/debug/app-focus-webkit-debug.apk'
 reinstall_app true


### PR DESCRIPTION
1. Screengrab needs debug build instead of firebase build after we change code base on UI testing.
2. Screengrab need to add permission  "android.permission.CHANGE_CONFIGURATION"  (refer: https://docs.fastlane.tools/actions/screengrab/) on Debug build.
3. app_package_name="org.mozilla.rocket.debug.pliu" is hard coded as debug build apply Suffix like ".debug." + userName. Any suggestion to this is welcomed. (I checked the document seems no customized parameter can send through command line.)  