### PR TITLE
fix browser menu step in MyShotScreenshot

### DIFF
--- a/app/src/androidTest/java/org/mozilla/focus/screengrab/MyShotScreenshot.java
+++ b/app/src/androidTest/java/org/mozilla/focus/screengrab/MyShotScreenshot.java
@@ -113,8 +113,8 @@ public class MyShotScreenshot extends BaseScreenshot {
         new BottomBarRobot().clickBrowserBottomBarItem(bottomBarCapturePos);
         IdlingRegistry.getInstance().register(screenshotIdlingResource);
 
-        // Open menu
-        AndroidTestUtils.tapHomeMenuButton();
+        // Open browser menu
+        AndroidTestUtils.tapBrowserMenuButton();
         IdlingRegistry.getInstance().unregister(screenshotIdlingResource);
 
         // Click my shot and take a screenshot of panel and toast


### PR DESCRIPTION
1. The scenario step is "open browser menu" (instead of "home menu") after user takes screenshot. 
2. verify by running Screengrab locally and it works