### PR TITLE
[Bug] Progress Bar loading forever when there's a prbloem getting News items.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -249,6 +249,10 @@ dependencies {
     kapt "com.google.dagger:dagger-compiler:${Versions.dagger}"
     kapt "com.google.dagger:dagger-android-processor:${Versions.dagger}"
 
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:${Versions.coroutine}"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:${Versions.coroutine}"
+
+
 
     testImplementation "junit:junit:${Versions.junit}"
     testImplementation "org.robolectric:robolectric:${Versions.robolectric}"

--- a/app/src/main/java/org/mozilla/rocket/content/news/data/NewsSourceManager.java
+++ b/app/src/main/java/org/mozilla/rocket/content/news/data/NewsSourceManager.java
@@ -9,6 +9,7 @@ import android.content.Context;
 import android.text.TextUtils;
 import android.util.Log;
 
+import org.mozilla.focus.utils.AppConfigWrapper;
 import org.mozilla.focus.utils.Settings;
 import org.mozilla.threadutils.ThreadUtils;
 
@@ -50,6 +51,13 @@ public class NewsSourceManager {
             } else {
                 newsSource = settings.getNewsSource();
                 Log.d(NewsSourceManager.TAG, "NewsSourceManager already set:" + newsSource);
+            }
+            // previously we only set the source url after remote config is fetched. But when there's no internet connection,
+            // the remote config's callback will never be called, thus newsSourceUrl will always be null.
+            // We try to set the url here if previously we already got the value from remote config.
+            final String url = AppConfigWrapper.getNewsProviderUrl(settings.getNewsSource());
+            if (!TextUtils.isEmpty(url)) {
+                this.newsSourceUrl = url;
             }
         });
     }

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -39,6 +39,7 @@ object Versions {
     const val jraska_falcon = "2.0.1"
     const val dagger = "2.17"
     const val androidx_test_core = "1.1.0"
+    const val coroutine = "1.2.0"
 }
 
 object SystemEnv {

--- a/components/utils/cachedrequestloader/src/main/java/org/mozilla/cachedrequestloader/BackgroundCachedRequestLoader.java
+++ b/components/utils/cachedrequestloader/src/main/java/org/mozilla/cachedrequestloader/BackgroundCachedRequestLoader.java
@@ -75,6 +75,8 @@ public class BackgroundCachedRequestLoader implements RequestLoaderDelegation.Re
                     requestLoaderDelegation.writeToCache(string);
                 }
             } catch (MalformedURLException e) {
+                // treat network error as no data
+                stringLiveData.postValue(new Pair<>(ResponseData.SOURCE_NETWORK, ""));
                 e.printStackTrace();
             }
         });


### PR DESCRIPTION
Steps to reproduce
1. Start the app with Internet connection
2. Restart the app. Go to Home panel
3. Enable airplane mode
4. Swipe up to display content portal, the News will load forever

Root cause
1. NewsSourceManager only updates its newsSourceUlr in the RemoteConfig callback, if we didn't get the callback, the news source URL will be null forever. And the Get request will throw an exception, and the user will never get a result.
2. We should limit the time of showing the loading progress bar.
3. Network request exception will be caught and LiveData is not updated.

For 1. I make NewsSourceManager.init() also init the source URL if it already had a vaolue
For 2. I use coroutoine job to display empty view once we see the loading progress. If the result comes before the threshold, we cancel that job.
For 3. Commit 2 fixed that problem.