### PR TITLE
Implement DialogQueue to help manage dialog showing order/strategy when there're multiple dialogs to be shown

### DIFF
--- a/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
+++ b/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
@@ -74,6 +74,7 @@ import org.mozilla.rocket.component.LaunchIntentDispatcher;
 import org.mozilla.rocket.component.PrivateSessionNotificationService;
 import org.mozilla.rocket.content.ContentPortalViewState;
 import org.mozilla.rocket.download.DownloadIndicatorViewModel;
+import org.mozilla.rocket.landing.DialogQueue;
 import org.mozilla.rocket.landing.OrientationState;
 import org.mozilla.rocket.landing.PortraitComponent;
 import org.mozilla.rocket.landing.PortraitStateModel;
@@ -88,6 +89,8 @@ import org.mozilla.rocket.tabs.TabView;
 import org.mozilla.rocket.tabs.TabViewProvider;
 import org.mozilla.rocket.tabs.TabsSessionProvider;
 import org.mozilla.rocket.theme.ThemeManager;
+import org.mozilla.rocket.widget.PromotionDialog;
+import org.mozilla.rocket.widget.PromotionDialogExt;
 
 import java.io.File;
 import java.util.List;
@@ -125,6 +128,7 @@ public class MainActivity extends BaseActivity implements ThemeManager.ThemeHost
     private DownloadIndicatorViewModel downloadIndicatorViewModel;
 
     private PortraitStateModel portraitStateModel = new PortraitStateModel();
+    private DialogQueue dialogQueue = new DialogQueue();
 
     @Override
     public ThemeManager getThemeManager() {
@@ -771,8 +775,11 @@ public class MainActivity extends BaseActivity implements ThemeManager.ThemeHost
 
     @Override
     public void showRateAppDialog() {
-        DialogUtils.showRateAppDialog(this);
-        TelemetryWrapper.showRateApp(false);
+        PromotionDialog dialog = DialogUtils.createRateAppDialog(this);
+        PromotionDialogExt.enqueue(dialogQueue, dialog, () -> {
+            TelemetryWrapper.showRateApp(false);
+            return null;
+        });
     }
 
     @Override
@@ -783,8 +790,11 @@ public class MainActivity extends BaseActivity implements ThemeManager.ThemeHost
 
     @Override
     public void showShareAppDialog() {
-        DialogUtils.showShareAppDialog(this);
-        TelemetryWrapper.showPromoteShareDialog();
+        PromotionDialog dialog = DialogUtils.createShareAppDialog(this);
+        PromotionDialogExt.enqueue(dialogQueue, dialog, () -> {
+            TelemetryWrapper.showPromoteShareDialog();
+            return null;
+        });
     }
 
     @Override
@@ -795,9 +805,11 @@ public class MainActivity extends BaseActivity implements ThemeManager.ThemeHost
 
     @Override
     public void showRateAppDialogFromIntent() {
-
-        DialogUtils.showRateAppDialog(this);
-        TelemetryWrapper.showRateApp(false);
+        PromotionDialog dialog = DialogUtils.createRateAppDialog(this);
+        PromotionDialogExt.enqueue(dialogQueue, dialog, () -> {
+            TelemetryWrapper.showRateApp(false);
+            return null;
+        });
 
         NotificationManagerCompat.from(this).cancel(NotificationId.LOVE_FIREFOX);
 

--- a/app/src/main/java/org/mozilla/focus/settings/SettingsFragment.java
+++ b/app/src/main/java/org/mozilla/focus/settings/SettingsFragment.java
@@ -5,7 +5,7 @@
 
 package org.mozilla.focus.settings;
 
-import android.content.Context;
+import android.app.Activity;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.res.Resources;
@@ -61,22 +61,22 @@ public class SettingsFragment extends PreferenceFragment implements SharedPrefer
         TelemetryWrapper.settingsClickEvent(keyClicked);
 
         if (keyClicked.equals(resources.getString(R.string.pref_key_give_feedback))) {
-            DialogUtils.showRateAppDialog(getActivity());
+            DialogUtils.createRateAppDialog(preference.getContext()).show();
         } else if (keyClicked.equals(resources.getString(R.string.pref_key_share_with_friends))) {
             if (!debugingFirebase()) {
-                DialogUtils.showShareAppDialog(getActivity());
+                DialogUtils.createShareAppDialog(preference.getContext()).show();
             }
         } else if (keyClicked.equals(resources.getString(R.string.pref_key_about))) {
-            final Intent intent = InfoActivity.getAboutIntent(getActivity());
+            final Intent intent = InfoActivity.getAboutIntent(preference.getContext());
             startActivity(intent);
         } else if (keyClicked.equals(resources.getString(R.string.pref_key_night_mode_brightness))) {
-            Settings.getInstance(getActivity()).setNightModeSpotlight(true);
-            startActivity(AdjustBrightnessDialog.Intents.INSTANCE.getStartIntentFromSetting(getActivity()));
+            Settings.getInstance(preference.getContext()).setNightModeSpotlight(true);
+            startActivity(AdjustBrightnessDialog.Intents.INSTANCE.getStartIntentFromSetting(preference.getContext()));
         } else if (keyClicked.equals(resources.getString(R.string.pref_key_default_browser))) {
             TelemetryWrapper.clickDefaultBrowserInSetting();
         } else if (keyClicked.equals(resources.getString(R.string.pref_key_private_mode_shortcut))) {
             TelemetryWrapper.clickPrivateShortcutItemInSettings();
-            ShortcutUtils.Companion.createShortcut(getActivity().getApplicationContext());
+            ShortcutUtils.Companion.createShortcut(preference.getContext().getApplicationContext());
         }
 
         return super.onPreferenceTreeClick(preferenceScreen, preference);

--- a/app/src/main/java/org/mozilla/focus/utils/DialogUtils.java
+++ b/app/src/main/java/org/mozilla/focus/utils/DialogUtils.java
@@ -45,11 +45,7 @@ public class DialogUtils {
     private static final int REQUEST_DEFAULT_CLICK = 4;
     private static final int REQUEST_PRIVACY_POLICY_CLICK = 5;
 
-    public static void showRateAppDialog(final Context context) {
-        if (context == null) {
-            return;
-        }
-
+    public static PromotionDialog createRateAppDialog(@NonNull final Context context) {
         CustomViewDialogData data = new CustomViewDialogData();
 
         data.setDrawable(ContextCompat.getDrawable(context, R.drawable.promotion_02));
@@ -74,7 +70,7 @@ public class DialogUtils {
 
         data.setShowCloseButton(true);
 
-        new PromotionDialog(context, data)
+        return new PromotionDialog(context, data)
                 .onPositive(() -> {
                     IntentUtils.goToPlayStore(context);
                     telemetryFeedback(context, TelemetryWrapper.Value.POSITIVE);
@@ -96,10 +92,11 @@ public class DialogUtils {
                     telemetryFeedback(context, TelemetryWrapper.Value.DISMISS);
                     return null;
                 })
-                .setCancellable(true)
-                .show();
-
-        Settings.getInstance(context).setRateAppDialogDidShow();
+                .addOnShowListener(() -> {
+                    Settings.getInstance(context).setRateAppDialogDidShow();
+                    return null;
+                })
+                .setCancellable(true);
     }
 
     private static void telemetryFeedback(final Context context, String value) {
@@ -110,11 +107,7 @@ public class DialogUtils {
         }
     }
 
-    public static void showShareAppDialog(final Context context) {
-        if (context == null) {
-            return;
-        }
-
+    public static PromotionDialog createShareAppDialog(@NonNull final Context context) {
         CustomViewDialogData data = new CustomViewDialogData();
         data.setDrawable(ContextCompat.getDrawable(context, R.drawable.promotion_03));
         data.setTitle(AppConfigWrapper.getShareAppDialogTitle());
@@ -122,7 +115,7 @@ public class DialogUtils {
         data.setPositiveText(context.getString(R.string.share_app_dialog_btn_share));
         data.setShowCloseButton(true);
 
-        new PromotionDialog(context, data)
+        return new PromotionDialog(context, data)
                 .onPositive(() -> {
                     Intent sendIntent = new Intent(Intent.ACTION_SEND);
                     sendIntent.setType("text/plain");
@@ -140,10 +133,11 @@ public class DialogUtils {
                     telemetryShareApp(context, TelemetryWrapper.Value.DISMISS);
                     return null;
                 })
-                .setCancellable(true)
-                .show();
-
-        Settings.getInstance(context).setShareAppDialogDidShow();
+                .addOnShowListener(() -> {
+                    Settings.getInstance(context).setShareAppDialogDidShow();
+                    return null;
+                })
+                .setCancellable(true);
     }
 
     private static void telemetryShareApp(final Context context, String value) {

--- a/app/src/main/java/org/mozilla/rocket/landing/DialogQueue.kt
+++ b/app/src/main/java/org/mozilla/rocket/landing/DialogQueue.kt
@@ -1,0 +1,60 @@
+/* -*- Mode: Java; c-basic-offset: 4; tab-width: 4; indent-tabs-mode: nil; -*-
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.rocket.landing
+
+import java.util.ArrayDeque
+
+class DialogQueue {
+    private var currentDialog: DialogDelegate? = null
+    private val queue = ArrayDeque<DialogDelegate>()
+
+    /**
+     * FIFO queue for dialogs to be shown at the same time
+     * @param dialog operations dialog needs to support in order to work with DialogQueue
+     */
+    fun enqueue(dialog: DialogDelegate) {
+        if (isShowing()) {
+            queue.offer(dialog)
+        } else {
+            showDialog(dialog)
+        }
+    }
+
+    /**
+     * Show dialog only if there's no any other dialog showing
+     * @param dialog operations dialog needs to support in order to work with DialogQueue
+     */
+    fun tryShow(dialog: DialogDelegate): Boolean {
+        if (!isShowing()) {
+            showDialog(dialog)
+            return true
+        }
+        return false
+    }
+
+    private fun nextDialog() {
+        if (queue.isEmpty()) {
+            return
+        }
+        showDialog(queue.removeFirst())
+    }
+
+    private fun showDialog(dialog: DialogDelegate) {
+        currentDialog = dialog
+        dialog.setOnDismissListener {
+            currentDialog = null
+            nextDialog()
+        }
+        dialog.show()
+    }
+
+    private fun isShowing() = currentDialog != null
+
+    interface DialogDelegate {
+        fun setOnDismissListener(listener: () -> Unit)
+        fun show()
+    }
+}


### PR DESCRIPTION
This is a preliminary PR to #3585.

As the number of dialogs will increase over time, dialogs belong to different features or being shown by components with different lifecycles/executing order, it's possible multiple dialogs would be popped at the same time during app launch.

DialogQueue provides basic queuing/peeking mechanism. A dialog can decide to queue itself, so multiple dialogs will be shown one after the other, or it can decide to show only if when there's no other dialog showing.