### PR TITLE
fixes crash when opening menu

### DIFF
--- a/app/src/main/java/org/mozilla/rocket/chrome/ChromeViewModel.kt
+++ b/app/src/main/java/org/mozilla/rocket/chrome/ChromeViewModel.kt
@@ -94,6 +94,8 @@ class ChromeViewModel(
         isRefreshing.value = false
         canGoBack.value = false
         canGoForward.value = false
+        isHomePageUrlInputShowing.value = false
+        isMyShotOnBoardingPending.value = false
 
         isCurrentUrlBookmarked = Transformations.switchMap<String, List<BookmarkModel>>(currentUrl, bookmarkRepo::getBookmarksByUrl)
                 .let { urlBookmarksLiveData ->


### PR DESCRIPTION
fixes https://github.com/mozilla-tw/FirefoxLite/issues/3676#issuecomment-507107809
fixes first time menu open crash by giving default values to the LiveData 'isHomePageUrlInputShowing' and 'isMyShotOnBoardingPending' in ChromeViewModel