### PR TITLE
Show ellipsis if news category text is too long to fit in the bubble

### DIFF
--- a/app/src/main/res/layout/content_tab_new_setting_item.xml
+++ b/app/src/main/res/layout/content_tab_new_setting_item.xml
@@ -14,15 +14,18 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License
   -->
-<ToggleButton
-        xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:tools="http://schemas.android.com/tools"
-        android:id="@+id/news_setting_cat_item"
-        android:layout_width="match_parent"
-        android:layout_height="32dp"
-        android:layout_marginStart="4dp"
-        android:layout_marginEnd="4dp"
-        android:layout_marginTop="9dp"
-        android:textColor="@color/content_setting_lang_txt"
-        android:background="@drawable/content_setting_lang_bg"
-        tools:textOff="english"/>
+<ToggleButton xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/news_setting_cat_item"
+    android:layout_width="match_parent"
+    android:layout_height="32dp"
+    android:layout_marginStart="4dp"
+    android:layout_marginTop="9dp"
+    android:layout_marginEnd="4dp"
+    android:background="@drawable/content_setting_lang_bg"
+    android:ellipsize="end"
+    android:lines="1"
+    android:paddingStart="12dp"
+    android:paddingEnd="12dp"
+    android:textColor="@color/content_setting_lang_txt"
+    tools:textOff="english" />


### PR DESCRIPTION

![device-2019-07-04-105740](https://user-images.githubusercontent.com/7045016/60638399-d505a500-9e50-11e9-93c8-82beb8281df2.png)

Close #3734 