### PR TITLE
allows to show/copy firebase id for in-app-message debugging usage

### DIFF
--- a/app/src/main/java/org/mozilla/rocket/debugging/DebugActivity.kt
+++ b/app/src/main/java/org/mozilla/rocket/debugging/DebugActivity.kt
@@ -1,5 +1,7 @@
 package org.mozilla.rocket.debugging
 
+import android.content.ClipData
+import android.content.ClipboardManager
 import android.content.Context
 import android.content.Intent
 import android.content.SharedPreferences
@@ -8,8 +10,10 @@ import android.widget.ArrayAdapter
 import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.Observer
+import kotlinx.android.synthetic.main.activity_debug.debug_firebase_id
 import kotlinx.android.synthetic.main.activity_debug.debug_locale_layout
 import kotlinx.android.synthetic.main.activity_debug.debug_locale_text
 import kotlinx.android.synthetic.main.activity_debug.debug_mission_reminder
@@ -17,6 +21,7 @@ import kotlinx.android.synthetic.main.activity_debug.toolbar
 import org.json.JSONArray
 import org.mozilla.focus.R
 import org.mozilla.focus.utils.FirebaseHelper
+import org.mozilla.rocket.content.appContext
 import org.mozilla.rocket.preference.stringLiveData
 import java.util.concurrent.TimeUnit
 
@@ -47,6 +52,11 @@ class DebugActivity : AppCompatActivity() {
         })
         debug_locale_layout.setOnClickListener {
             showDropDownListDialog(debugLocales)
+        }
+        debug_firebase_id.setOnClickListener {
+            val firebaseId = FirebaseHelper.getFirebase().getInstanceId() ?: "null"
+            copyToClipboard("firebaseId", firebaseId)
+            Toast.makeText(this, "$firebaseId copied", Toast.LENGTH_LONG).show()
         }
     }
 
@@ -87,6 +97,12 @@ class DebugActivity : AppCompatActivity() {
         debug_mission_reminder.setOnClickListener {
             isMissionReminderDebugEnabled = true
             Toast.makeText(this, "Repeat interval has been set to 15 minutes", Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    private fun copyToClipboard(label: String, text: String) {
+        ContextCompat.getSystemService(applicationContext, ClipboardManager::class.java)?.run {
+            primaryClip = ClipData.newPlainText(label, text)
         }
     }
 

--- a/app/src/main/res/layout/activity_debug.xml
+++ b/app/src/main/res/layout/activity_debug.xml
@@ -54,4 +54,20 @@
 
     </LinearLayout>
 
+    <LinearLayout
+        android:id="@+id/debug_firebase_id"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="16dp">
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textSize="16sp"
+            android:textColor="@android:color/black"
+            android:text="Firebase ID"/>
+
+    </LinearLayout>
+
 </LinearLayout>

--- a/firebase/src/main/java/org/mozilla/focus/utils/FirebaseContract.kt
+++ b/firebase/src/main/java/org/mozilla/focus/utils/FirebaseContract.kt
@@ -23,6 +23,8 @@ abstract class FirebaseContract(var remoteConfigDefault: HashMap<String, Any> = 
 
     abstract fun getRcBoolean(key: String): Boolean
 
+    abstract fun getInstanceId(): String?
+
     abstract fun deleteInstanceId()
 
     abstract fun enableAnalytics(context: Context, enable: Boolean)

--- a/firebase/src/main/java/org/mozilla/focus/utils/FirebaseImp.kt
+++ b/firebase/src/main/java/org/mozilla/focus/utils/FirebaseImp.kt
@@ -48,6 +48,16 @@ open class FirebaseImp(fromResourceString: HashMap<String, Any>) : FirebaseContr
         return remoteConfig.getBoolean(key)
     }
 
+    override fun getInstanceId(): String? = try {
+        // This method is synchronized and runs in background thread
+        FirebaseInstanceId.getInstance().id
+
+        // below catch is important, if the app starts with Firebase disabled, calling getInstance()
+        // will throw IllegalStateException
+    } catch (e: IOException) {
+        null
+    }
+
     @WorkerThread
     override fun deleteInstanceId() {
         try {

--- a/firebase/src/main/java/org/mozilla/focus/utils/FirebaseNoOpImp.kt
+++ b/firebase/src/main/java/org/mozilla/focus/utils/FirebaseNoOpImp.kt
@@ -45,6 +45,8 @@ open class FirebaseNoOpImp(remoteConfigDefault: HashMap<String, Any> = HashMap()
         return FIREBASE_BOOLEAN_DEFAULT
     }
 
+    override fun getInstanceId(): String? = null
+
     override fun deleteInstanceId() {
     }
 


### PR DESCRIPTION
allows to see the firebaseId in debug page that can help QA to debug In-App-Messaging

![device-2019-12-11-174012](https://user-images.githubusercontent.com/5226898/70609883-8a792780-1c3d-11ea-987c-173a6f89ced3.png)
