### PR TITLE
support D1 notification deeplink

### DIFF
--- a/app/src/main/java/org/mozilla/focus/notification/NotificationActionBroadcastReceiver.java
+++ b/app/src/main/java/org/mozilla/focus/notification/NotificationActionBroadcastReceiver.java
@@ -42,21 +42,33 @@ public class NotificationActionBroadcastReceiver extends BroadcastReceiver {
         }
         Intent nexStep = null;
 
-        if (bundle.getBoolean(IntentUtils.EXTRA_NOTIFICATION_DELETE_FIREBASE_NOTIFICATION)) {
-            String messageId = bundle.getString(IntentUtils.EXTRA_NOTIFICATION_MESSAGE_ID, "");
+        if (bundle.getBoolean(IntentUtils.EXTRA_NOTIFICATION_DELETE_NOTIFICATION)) {
+            String source = bundle.getString(IntentUtils.EXTRA_NOTIFICATION_NOTIFICATION_SOURCE);
             String link = bundle.getString(IntentUtils.EXTRA_NOTIFICATION_LINK, "");
-            TelemetryWrapper.dismissNotification(link, messageId);
+            if (IntentUtils.NOTIFICATION_SOURCE_FIREBASE.equals(source)) {
+                String messageId = bundle.getString(IntentUtils.EXTRA_NOTIFICATION_MESSAGE_ID, "");
+                TelemetryWrapper.dismissNotification(link, messageId);
+            } else if (IntentUtils.NOTIFICATION_SOURCE_FIRSTRUN.equals(source)) {
+                String message = bundle.getString(IntentUtils.EXTRA_NOTIFICATION_MESSAGE, "");
+                TelemetryWrapper.dismissFirstrunNotification(link, message);
+            }
 
-        } else if (bundle.getBoolean(IntentUtils.EXTRA_NOTIFICATION_CLICK_FIREBASE_NOTIFICATION)) {
+        } else if (bundle.getBoolean(IntentUtils.EXTRA_NOTIFICATION_CLICK_NOTIFICATION)) {
             nexStep = new Intent();
             nexStep.setClassName(context, AppConstants.LAUNCHER_ACTIVITY_ALIAS);
             nexStep.putExtra(FirebaseMessagingServiceWrapper.PUSH_OPEN_URL, intent.getStringExtra(IntentUtils.EXTRA_NOTIFICATION_OPEN_URL));
             nexStep.putExtra(FirebaseMessagingServiceWrapper.PUSH_COMMAND, intent.getStringExtra(IntentUtils.EXTRA_NOTIFICATION_COMMAND));
             nexStep.putExtra(FirebaseMessagingServiceWrapper.PUSH_DEEP_LINK, intent.getStringExtra(IntentUtils.EXTRA_NOTIFICATION_DEEP_LINK));
 
-            String messageId = bundle.getString(IntentUtils.EXTRA_NOTIFICATION_MESSAGE_ID, "");
+            String source = bundle.getString(IntentUtils.EXTRA_NOTIFICATION_NOTIFICATION_SOURCE);
             String link = bundle.getString(IntentUtils.EXTRA_NOTIFICATION_LINK, "");
-            TelemetryWrapper.openNotification(link, messageId, false);
+            if (IntentUtils.NOTIFICATION_SOURCE_FIREBASE.equals(source)) {
+                String messageId = bundle.getString(IntentUtils.EXTRA_NOTIFICATION_MESSAGE_ID, "");
+                TelemetryWrapper.openNotification(link, messageId, false);
+            } else if (IntentUtils.NOTIFICATION_SOURCE_FIRSTRUN.equals(source)) {
+                String message = bundle.getString(IntentUtils.EXTRA_NOTIFICATION_MESSAGE, "");
+                TelemetryWrapper.openD1Notification(link, message);
+            }
 
         } else if (bundle.getBoolean(IntentUtils.EXTRA_NOTIFICATION_ACTION_RATE_STAR)) {
 

--- a/app/src/main/java/org/mozilla/focus/notification/RocketMessagingService.java
+++ b/app/src/main/java/org/mozilla/focus/notification/RocketMessagingService.java
@@ -35,8 +35,7 @@ public class RocketMessagingService extends FirebaseMessagingServiceWrapper {
             messageId,
             parseOpenUrl(intent),
             parseCommand(intent),
-            parseDeepLink(intent),
-            parseLink(intent)
+            parseDeepLink(intent)
         );
         final NotificationCompat.Builder builder = NotificationUtil.importantBuilder(this)
                 .setContentIntent(pendingIntent);
@@ -83,15 +82,14 @@ public class RocketMessagingService extends FirebaseMessagingServiceWrapper {
         return link;
     }
 
-    private PendingIntent getClickPendingIntent(Context appContext, String messageId, String openUrl, String command, String deepLink, String link) {
+    private PendingIntent getClickPendingIntent(Context appContext, String messageId, String openUrl, String command, String deepLink) {
         // RocketLauncherActivity will handle this intent
         Intent clickIntent = IntentUtils.genFirebaseNotificationClickForBroadcastReceiver(
                 appContext,
                 messageId,
                 openUrl,
                 command,
-                deepLink,
-                link
+                deepLink
         );
         return PendingIntent.getBroadcast(this, REQUEST_CODE_CLICK_NOTIFICATION, clickIntent, PendingIntent.FLAG_ONE_SHOT);
     }

--- a/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
+++ b/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
@@ -2510,6 +2510,24 @@ object TelemetryWrapper {
     }
 
     @TelemetryDoc(
+            name = "Dismiss D1 Notification",
+            category = Category.ACTION,
+            method = Method.SWIPE,
+            `object` = Object.FIRSTRUN_PUSH,
+            value = Value.DISMISS,
+            extras = [
+                TelemetryExtra(name = Extra.LINK, value = "${Extra_Value.URL},${Extra_Value.DEEPLINK},null"),
+                TelemetryExtra(name = Extra.MESSAGE, value = "message")
+            ])
+    @JvmStatic
+    fun dismissFirstrunNotification(link: String?, message: String?) {
+        EventBuilder(Category.ACTION, Method.SWIPE, Object.FIRSTRUN_PUSH, Value.DISMISS)
+                .extra(Extra.LINK, link ?: "null")
+                .extra(Extra.MESSAGE, message ?: "null")
+                .queue()
+    }
+
+    @TelemetryDoc(
             name = "Open Notification",
             category = Category.ACTION,
             method = Method.OPEN,
@@ -2526,6 +2544,24 @@ object TelemetryWrapper {
                 .extra(Extra.LINK, link ?: "null")
                 .extra(Extra.MESSAGE_ID, messageId ?: "null")
                 .extra(Extra.BACKGROUND, background.toString())
+                .queue()
+    }
+
+    @TelemetryDoc(
+            name = "Open D1 Notification",
+            category = Category.ACTION,
+            method = Method.OPEN,
+            `object` = Object.FIRSTRUN_PUSH,
+            value = "",
+            extras = [
+                TelemetryExtra(name = Extra.LINK, value = "${Extra_Value.URL},${Extra_Value.DEEPLINK},null"),
+                TelemetryExtra(name = Extra.MESSAGE, value = "message")
+            ])
+    @JvmStatic
+    fun openD1Notification(link: String?, message: String?) {
+        EventBuilder(Category.ACTION, Method.OPEN, Object.FIRSTRUN_PUSH)
+                .extra(Extra.LINK, link ?: "null")
+                .extra(Extra.MESSAGE, message ?: "null")
                 .queue()
     }
 

--- a/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
+++ b/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
@@ -1897,13 +1897,15 @@ object TelemetryWrapper {
             value = "",
             extras = [
                 TelemetryExtra(name = Extra.DELAY, value = "minutes"),
-                TelemetryExtra(name = Extra.MESSAGE, value = "message")
+                TelemetryExtra(name = Extra.MESSAGE, value = "message"),
+                TelemetryExtra(name = Extra.LINK, value = "url|deeplink|null")
             ])
     @JvmStatic
-    fun receiveFirstrunConfig(minutes: Long, message: String?) {
+    fun receiveFirstrunConfig(minutes: Long, message: String?, link: String?) {
         val builder = EventBuilder(Category.ACTION, Method.GET, Object.FIRSTRUN_PUSH)
                 .extra(Extra.DELAY, minutes.toString())
                 .extra(Extra.MESSAGE, message ?: "")
+                .extra(Extra.LINK, link ?: "")
         builder.queue()
     }
 
@@ -1915,13 +1917,15 @@ object TelemetryWrapper {
             value = "",
             extras = [
                 TelemetryExtra(name = Extra.DELAY, value = "minutes"),
-                TelemetryExtra(name = Extra.MESSAGE, value = "message")
+                TelemetryExtra(name = Extra.MESSAGE, value = "message"),
+                TelemetryExtra(name = Extra.LINK, value = "url|deeplink|null")
             ])
     @JvmStatic
-    fun showFirstrunNotification(minutes: Long, message: String?) {
+    fun showFirstrunNotification(minutes: Long, message: String?, link: String?) {
         val builder = EventBuilder(Category.ACTION, Method.SHOW, Object.FIRSTRUN_PUSH)
                 .extra(Extra.DELAY, minutes.toString())
                 .extra(Extra.MESSAGE, message ?: "")
+                .extra(Extra.LINK, link ?: "")
         builder.queue()
     }
 

--- a/app/src/main/java/org/mozilla/focus/utils/AppConfigWrapper.java
+++ b/app/src/main/java/org/mozilla/focus/utils/AppConfigWrapper.java
@@ -85,8 +85,8 @@ public class AppConfigWrapper {
         return FirebaseHelper.getFirebase().getRcLong(FirebaseHelper.FIRST_LAUNCH_TIMER_MINUTES);
     }
 
-    public static String getFirstLaunchNotificationMessage() {
-        return FirebaseHelper.getFirebase().getRcString(FirebaseHelper.FIRST_LAUNCH_NOTIFICATION_MESSAGE);
+    public static String getFirstLaunchNotification() {
+        return FirebaseHelper.getFirebase().getRcString(FirebaseHelper.FIRST_LAUNCH_NOTIFICATION);
     }
 
     static String getShareAppDialogTitle() {

--- a/app/src/main/java/org/mozilla/focus/utils/FirebaseHelper.kt
+++ b/app/src/main/java/org/mozilla/focus/utils/FirebaseHelper.kt
@@ -47,7 +47,7 @@ object FirebaseHelper {
     internal const val ENABLE_MY_SHOT_UNREAD = "enable_my_shot_unread"
     internal const val SCREENSHOT_CATEGORY_MANIFEST = "screenshot_category_manifest"
     internal const val FIRST_LAUNCH_TIMER_MINUTES = "first_launch_timer_minutes"
-    internal const val FIRST_LAUNCH_NOTIFICATION_MESSAGE = "first_launch_notification_message"
+    internal const val FIRST_LAUNCH_NOTIFICATION = "first_launch_notification"
 
     private const val FIREBASE_WEB_ID = "default_web_client_id"
     private const val FIREBASE_DB_URL = "firebase_database_url"
@@ -235,7 +235,7 @@ object FirebaseHelper {
             map[RATE_APP_DIALOG_TEXT_CONTENT] = context.getString(R.string.rate_app_dialog_text_content)
             map[RATE_APP_DIALOG_TEXT_POSITIVE] = context.getString(R.string.rate_app_dialog_btn_go_rate)
             map[RATE_APP_DIALOG_TEXT_NEGATIVE] = context.getString(R.string.rate_app_dialog_btn_feedback)
-            map[FIRST_LAUNCH_NOTIFICATION_MESSAGE] =
+            map[FIRST_LAUNCH_NOTIFICATION] =
                 context.getString(R.string.preference_default_browser) + "?\uD83D\uDE0A"
             // Share App
             map[STR_SHARE_APP_DIALOG_TITLE] = context.getString(

--- a/app/src/main/java/org/mozilla/focus/utils/IntentUtils.java
+++ b/app/src/main/java/org/mozilla/focus/utils/IntentUtils.java
@@ -41,6 +41,7 @@ public class IntentUtils {
     public static final String EXTRA_SHOW_RATE_DIALOG = "show_rate_dialog";
 
     public static final String EXTRA_NOTIFICATION_MESSAGE_ID = "ex_no_message_id";
+    public static final String EXTRA_NOTIFICATION_MESSAGE = "ex_no_message";
     public static final String EXTRA_NOTIFICATION_LINK = "ex_no_link";
     public static final String EXTRA_NOTIFICATION_OPEN_URL = "ex_no_open_url";
     public static final String EXTRA_NOTIFICATION_COMMAND = "ex_no_command";
@@ -51,10 +52,14 @@ public class IntentUtils {
     public static final String EXTRA_NOTIFICATION_CLICK_DEFAULT_BROWSER = "ex_no_click_default_browser";
     public static final String EXTRA_NOTIFICATION_CLICK_LOVE_FIREFOX = "ex_no_click_love_firefox";
     public static final String EXTRA_NOTIFICATION_CLICK_PRIVACY_POLICY_UPDATE = "ex_no_click_privacy_policy_update";
-    public static final String EXTRA_NOTIFICATION_DELETE_FIREBASE_NOTIFICATION = "ex_no_delete_firebase_notification";
-    public static final String EXTRA_NOTIFICATION_CLICK_FIREBASE_NOTIFICATION = "ex_no_click_firebase_notification";
+    public static final String EXTRA_NOTIFICATION_NOTIFICATION_SOURCE = "ex_no_notification_source";
+    public static final String EXTRA_NOTIFICATION_DELETE_NOTIFICATION = "ex_no_delete_notification";
+    public static final String EXTRA_NOTIFICATION_CLICK_NOTIFICATION = "ex_no_click_notification";
 
     public static final String ACTION_NOTIFICATION = "action_notification";
+
+    public static final String NOTIFICATION_SOURCE_FIREBASE = "notification_source_firebase";
+    public static final String NOTIFICATION_SOURCE_FIRSTRUN = "notification_source_firstrun";
 
 
     /**
@@ -269,11 +274,24 @@ public class IntentUtils {
     }
 
     public static Intent genDeleteFirebaseNotificationActionForBroadcastReceiver(Context context, String messageId, String link) {
-        final Intent deleteNotification = new Intent(context, NotificationActionBroadcastReceiver.class);
-        deleteNotification.setAction(IntentUtils.ACTION_NOTIFICATION);
-        deleteNotification.putExtra(IntentUtils.EXTRA_NOTIFICATION_DELETE_FIREBASE_NOTIFICATION, true);
+        final Intent deleteNotification = genDeleteNotificationActionForBroadcastReceiver(context, NOTIFICATION_SOURCE_FIREBASE);
         deleteNotification.putExtra(EXTRA_NOTIFICATION_MESSAGE_ID, messageId);
         deleteNotification.putExtra(EXTRA_NOTIFICATION_LINK, link);
+        return deleteNotification;
+    }
+
+    public static Intent genDeleteFirstrunNotificationActionForBroadcastReceiver(Context context, String message, String link) {
+        final Intent deleteNotification = genDeleteNotificationActionForBroadcastReceiver(context, NOTIFICATION_SOURCE_FIRSTRUN);
+        deleteNotification.putExtra(EXTRA_NOTIFICATION_MESSAGE, message);
+        deleteNotification.putExtra(EXTRA_NOTIFICATION_LINK, link);
+        return deleteNotification;
+    }
+
+    public static Intent genDeleteNotificationActionForBroadcastReceiver(Context context, String source) {
+        final Intent deleteNotification = new Intent(context, NotificationActionBroadcastReceiver.class);
+        deleteNotification.setAction(ACTION_NOTIFICATION);
+        deleteNotification.putExtra(EXTRA_NOTIFICATION_DELETE_NOTIFICATION, true);
+        deleteNotification.putExtra(EXTRA_NOTIFICATION_NOTIFICATION_SOURCE, source);
         return deleteNotification;
     }
 
@@ -282,18 +300,41 @@ public class IntentUtils {
         String messageId,
         String openUrl,
         String command,
-        String deepLink,
-        String link
+        String deepLink
     ) {
-        final Intent clickFirebaseNotification = new Intent(context, NotificationActionBroadcastReceiver.class);
-        clickFirebaseNotification.setAction(IntentUtils.ACTION_NOTIFICATION);
-        clickFirebaseNotification.putExtra(IntentUtils.EXTRA_NOTIFICATION_CLICK_FIREBASE_NOTIFICATION, true);
-        clickFirebaseNotification.putExtra(EXTRA_NOTIFICATION_MESSAGE_ID, messageId);
-        clickFirebaseNotification.putExtra(EXTRA_NOTIFICATION_OPEN_URL, openUrl);
-        clickFirebaseNotification.putExtra(EXTRA_NOTIFICATION_COMMAND, command);
-        clickFirebaseNotification.putExtra(EXTRA_NOTIFICATION_DEEP_LINK, deepLink);
-        clickFirebaseNotification.putExtra(EXTRA_NOTIFICATION_LINK, link);
-        return clickFirebaseNotification;
+        final Intent intent = genNotificationActionIntent(context, NOTIFICATION_SOURCE_FIREBASE, openUrl, command, deepLink);
+        intent.putExtra(EXTRA_NOTIFICATION_MESSAGE_ID, messageId);
+        return intent;
+    }
+
+    public static Intent genFirstrunNotificationClickForBroadcastReceiver(
+        Context context,
+        String message,
+        String openUrl,
+        String command,
+        String deepLink
+    ) {
+        final Intent intent = genNotificationActionIntent(context, NOTIFICATION_SOURCE_FIRSTRUN, openUrl, command, deepLink);
+        intent.putExtra(EXTRA_NOTIFICATION_MESSAGE, message);
+        return intent;
+    }
+
+    private static Intent genNotificationActionIntent(
+        Context context,
+        String notificationSource,
+        String openUrl,
+        String command,
+        String deepLink
+    ) {
+        final Intent intent = new Intent(context, NotificationActionBroadcastReceiver.class);
+        intent.setAction(ACTION_NOTIFICATION);
+        intent.putExtra(EXTRA_NOTIFICATION_CLICK_NOTIFICATION, true);
+        intent.putExtra(EXTRA_NOTIFICATION_NOTIFICATION_SOURCE, notificationSource);
+        intent.putExtra(EXTRA_NOTIFICATION_OPEN_URL, openUrl);
+        intent.putExtra(EXTRA_NOTIFICATION_COMMAND, command);
+        intent.putExtra(EXTRA_NOTIFICATION_DEEP_LINK, deepLink);
+        intent.putExtra(EXTRA_NOTIFICATION_LINK, openUrl != null ? openUrl : (command != null ? command : deepLink));
+        return intent;
     }
 
     @CheckResult

--- a/app/src/main/java/org/mozilla/rocket/periodic/FirstLaunchWorker.kt
+++ b/app/src/main/java/org/mozilla/rocket/periodic/FirstLaunchWorker.kt
@@ -1,14 +1,19 @@
 package org.mozilla.rocket.periodic
 
+import android.app.PendingIntent
 import android.content.Context
 import android.content.SharedPreferences
 import android.preference.PreferenceManager
 import androidx.work.Worker
 import androidx.work.WorkerParameters
+import org.json.JSONException
+import org.json.JSONObject
 import org.mozilla.focus.BuildConfig
+import org.mozilla.focus.notification.FirebaseMessagingServiceWrapper
+import org.mozilla.focus.notification.NotificationUtil
 import org.mozilla.focus.telemetry.TelemetryWrapper
 import org.mozilla.focus.utils.AppConfigWrapper
-import org.mozilla.focus.utils.DialogUtils
+import org.mozilla.focus.utils.IntentUtils
 
 class FirstLaunchWorker(context: Context, workerParams: WorkerParameters) : Worker(context, workerParams) {
 
@@ -37,11 +42,47 @@ class FirstLaunchWorker(context: Context, workerParams: WorkerParameters) : Work
     }
 
     override fun doWork(): Result {
-        val message = AppConfigWrapper.getFirstLaunchNotificationMessage()
-        DialogUtils.showDefaultSettingNotification(applicationContext, message)
-        TelemetryWrapper.showFirstrunNotification(AppConfigWrapper.getFirstLaunchWorkerTimer(), message)
+        val firstrunNotification = AppConfigWrapper.getFirstLaunchNotification().jsonStringToFirstrunNotification()
+        firstrunNotification?.run {
+            showNotification(applicationContext, message, openUrl, command, deepLink)
+            TelemetryWrapper.showFirstrunNotification(AppConfigWrapper.getFirstLaunchWorkerTimer(), message)
+            setNotificationFired(applicationContext, true)
+        }
 
-        setNotificationFired(applicationContext, true)
         return Result.success()
+    }
+
+    private fun showNotification(context: Context, message: String, openUrl: String?, command: String?, deepLink: String?) {
+        val intent = IntentUtils.genFirebaseNotificationClickForBroadcastReceiver(context, null, openUrl, command, deepLink, null)
+        val openRocketPending = PendingIntent.getBroadcast(context, 0, intent,
+                PendingIntent.FLAG_ONE_SHOT)
+        val builder = NotificationUtil.importantBuilder(context)
+                .setContentTitle(message)
+                .setContentIntent(openRocketPending)
+        // Show notification
+        val id = message.hashCode()
+        NotificationUtil.sendNotification(context, id, builder)
+    }
+}
+
+class FirstrunNotification(
+    val message: String,
+    val openUrl: String?,
+    val command: String?,
+    val deepLink: String?
+)
+
+fun String.jsonStringToFirstrunNotification(): FirstrunNotification? {
+    return try {
+        val jsonObject = JSONObject(this)
+        FirstrunNotification(
+            jsonObject.getString("message"),
+            jsonObject.optString(FirebaseMessagingServiceWrapper.PUSH_OPEN_URL, null),
+            jsonObject.optString(FirebaseMessagingServiceWrapper.PUSH_COMMAND, null),
+            jsonObject.optString(FirebaseMessagingServiceWrapper.PUSH_DEEP_LINK, null)
+        )
+    } catch (e: JSONException) {
+        e.printStackTrace()
+        null
     }
 }

--- a/app/src/main/java/org/mozilla/rocket/periodic/FirstLaunchWorker.kt
+++ b/app/src/main/java/org/mozilla/rocket/periodic/FirstLaunchWorker.kt
@@ -49,7 +49,7 @@ class FirstLaunchWorker(context: Context, workerParams: WorkerParameters) : Work
         val firstrunNotification = AppConfigWrapper.getFirstLaunchNotification().jsonStringToFirstrunNotification()
         firstrunNotification?.run {
             showNotification(applicationContext, message, openUrl, command, deepLink)
-            TelemetryWrapper.showFirstrunNotification(AppConfigWrapper.getFirstLaunchWorkerTimer(), message)
+            TelemetryWrapper.showFirstrunNotification(AppConfigWrapper.getFirstLaunchWorkerTimer(), message, openUrl ?: command ?: deepLink)
             setNotificationFired(applicationContext, true)
         }
 

--- a/app/src/main/java/org/mozilla/rocket/periodic/PeriodicReceiver.kt
+++ b/app/src/main/java/org/mozilla/rocket/periodic/PeriodicReceiver.kt
@@ -60,7 +60,8 @@ class PeriodicReceiver : BroadcastReceiver() {
         workManager.enqueue(builder.build())
 
         val firstrunNotification = AppConfigWrapper.getFirstLaunchNotification().jsonStringToFirstrunNotification()
-        TelemetryWrapper.receiveFirstrunConfig(delayMinutes, firstrunNotification?.message)
+        val link = firstrunNotification?.openUrl ?: firstrunNotification?.command ?: firstrunNotification?.deepLink
+        TelemetryWrapper.receiveFirstrunConfig(delayMinutes, firstrunNotification?.message, link)
     }
 
     private fun calculateDelayMinutes(context: Context, delayMinutesToInstallTime: Long): Long {

--- a/app/src/main/java/org/mozilla/rocket/periodic/PeriodicReceiver.kt
+++ b/app/src/main/java/org/mozilla/rocket/periodic/PeriodicReceiver.kt
@@ -36,8 +36,9 @@ class PeriodicReceiver : BroadcastReceiver() {
         }
 
         val config = AppConfigWrapper.getFirstLaunchWorkerTimer()
-        val delayHoursToInstallTime = when (config.toInt()) {
+        val delayMinutesToInstallTime = when (config.toInt()) {
             FirstLaunchWorker.TIMER_DISABLED -> {
+                FirstLaunchWorker.setNotificationFired(context, true)
                 return
             }
             FirstLaunchWorker.TIMER_SUSPEND -> {
@@ -50,7 +51,7 @@ class PeriodicReceiver : BroadcastReceiver() {
                 config
             }
         }
-        val delayMinutes = calculateDelayMinutes(context, delayHoursToInstallTime)
+        val delayMinutes = calculateDelayMinutes(context, delayMinutesToInstallTime)
 
         workManager.cancelAllWorkByTag(FirstLaunchWorker.TAG)
         val builder = OneTimeWorkRequest.Builder(FirstLaunchWorker::class.java)

--- a/app/src/main/java/org/mozilla/rocket/periodic/PeriodicReceiver.kt
+++ b/app/src/main/java/org/mozilla/rocket/periodic/PeriodicReceiver.kt
@@ -59,8 +59,8 @@ class PeriodicReceiver : BroadcastReceiver() {
         builder.addTag(FirstLaunchWorker.TAG)
         workManager.enqueue(builder.build())
 
-        val message = AppConfigWrapper.getFirstLaunchNotificationMessage()
-        TelemetryWrapper.receiveFirstrunConfig(delayMinutes, message)
+        val firstrunNotification = AppConfigWrapper.getFirstLaunchNotification().jsonStringToFirstrunNotification()
+        TelemetryWrapper.receiveFirstrunConfig(delayMinutes, firstrunNotification?.message)
     }
 
     private fun calculateDelayMinutes(context: Context, delayMinutesToInstallTime: Long): Long {


### PR DESCRIPTION
based on #4559, please ignore the first commit

to fix #4506 #4507

remote config: `first_launch_notification`
Ex:
```
{
  "message": "test message",
  "push_deep_link": "rocket://content/travel"
}
```

```
{
  "message": "test message",
  "push_command": "SET_DEFAULT"
}
```
