### PR TITLE
release/hotfixUrlCrashTo2.1.5

### DIFF
--- a/app/src/main/java/org/mozilla/focus/download/DownloadInfoManager.java
+++ b/app/src/main/java/org/mozilla/focus/download/DownloadInfoManager.java
@@ -29,6 +29,7 @@ import org.mozilla.rocket.util.LoggerWrapper;
 import org.mozilla.threadutils.ThreadUtils;
 
 import java.io.File;
+import java.net.URISyntaxException;
 import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.List;
@@ -341,7 +342,13 @@ public class DownloadInfoManager {
             final Snackbar snackbar = Snackbar.make(container, completedStr, Snackbar.LENGTH_LONG);
             // Set the open action only if we can.
             if (existInDownloadManager) {
-                snackbar.setAction(R.string.open, view -> IntentUtils.intentOpenFile(container.getContext(), downloadInfo.getFileUri(), downloadInfo.getMimeType()));
+                snackbar.setAction(R.string.open, view -> {
+                    try {
+                        IntentUtils.intentOpenFile(container.getContext(), downloadInfo.getFileUri(), downloadInfo.getMimeType());
+                    } catch (URISyntaxException e) {
+                        e.printStackTrace();
+                    }
+                });
             }
             snackbar.show();
         });

--- a/app/src/main/java/org/mozilla/focus/utils/IntentUtils.java
+++ b/app/src/main/java/org/mozilla/focus/utils/IntentUtils.java
@@ -171,10 +171,10 @@ public class IntentUtils {
         builder.show();
     }
 
-    public static void intentOpenFile(Context context, String fileUriStr, String mimeType) {
+    public static void intentOpenFile(Context context, String fileUriStr, String mimeType) throws URISyntaxException {
         if (fileUriStr != null) {
             String authorities = BuildConfig.APPLICATION_ID + ".provider.fileprovider";
-            Uri fileUri = FileProvider.getUriForFile(context, authorities, new File(URI.create(fileUriStr).getPath()));
+            Uri fileUri = FileProvider.getUriForFile(context, authorities, new File(new URI(fileUriStr).getPath()));
 
             Intent launchIntent = new Intent(Intent.ACTION_VIEW);
             launchIntent.setDataAndType(fileUri, mimeType);

--- a/app/src/main/java/org/mozilla/focus/widget/DownloadListAdapter.java
+++ b/app/src/main/java/org/mozilla/focus/widget/DownloadListAdapter.java
@@ -29,6 +29,7 @@ import org.mozilla.threadutils.ThreadUtils;
 
 import java.io.File;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.List;
 
@@ -167,11 +168,21 @@ public class DownloadListAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
                 TelemetryWrapper.downloadOpenFile(false);
 
                 ThreadUtils.postToBackgroundThread(() -> {
-                    final boolean fileExist = new File(URI.create(download.getFileUri()).getPath()).exists();
+                    boolean fileExist = false;
+                    try {
+                        fileExist = new File(new URI(download.getFileUri()).getPath()).exists();
+                    } catch (URISyntaxException e) {
+                        e.printStackTrace();
+                    }
 
+                    final boolean finalFileExist = fileExist;
                     ThreadUtils.postToMainThread(() -> {
-                        if (fileExist) {
-                            IntentUtils.intentOpenFile(view.getContext(), download.getFileUri(), download.getMimeType());
+                        if (finalFileExist) {
+                            try {
+                                IntentUtils.intentOpenFile(view.getContext(), download.getFileUri(), download.getMimeType());
+                            } catch (URISyntaxException e) {
+                                e.printStackTrace();
+                            }
                         } else {
                             Toast.makeText(mContext, R.string.cannot_find_the_file, Toast.LENGTH_LONG).show();
                         }

--- a/app/src/main/java/org/mozilla/rocket/deeplink/DeepLinkType.kt
+++ b/app/src/main/java/org/mozilla/rocket/deeplink/DeepLinkType.kt
@@ -14,6 +14,7 @@ import org.mozilla.rocket.deeplink.task.StartTravelItemActivityTask
 import org.mozilla.rocket.deeplink.task.Task
 import org.mozilla.rocket.extension.getParam
 import java.net.URI
+import java.net.URISyntaxException
 
 enum class DeepLinkType {
 
@@ -140,19 +141,22 @@ enum class DeepLinkType {
 
     companion object {
         fun parse(url: String): DeepLinkType {
+            try {
+                val uri = URI(url)
 
-            val uri = URI.create(url)
+                for (type in values()) {
+                    if (type === NOT_SUPPORT) {
+                        continue
+                    }
 
-            for (type in values()) {
-                if (type === NOT_SUPPORT) {
-                    continue
+                    if (type.match(uri)) {
+                        type.addTasks(uri)
+
+                        return type
+                    }
                 }
-
-                if (type.match(uri)) {
-                    type.addTasks(uri)
-
-                    return type
-                }
+            } catch (e: URISyntaxException) {
+                e.printStackTrace()
             }
 
             return NOT_SUPPORT

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -4,7 +4,7 @@ object Versions {
     const val compile_sdk = 28
     const val build_tools = "28.0.3"
     const val version_code = 1
-    const val version_name = "2.1.4"
+    const val version_name = "2.1.5"
     const val android_gradle_plugin = "3.4.2"
     const val gms_oss_licenses_plugin = "0.9.3"
     const val support = "1.0.0"


### PR DESCRIPTION
1. Release team took v2.1.4 as base branch and then apply Hotfix https://github.com/mozilla-tw/FirefoxLite/pull/4615 onto new branch serving as v2.1.5 build to fix UrlCrash
2. version bumped to v2.1.5 
