### PR TITLE
show unread red dot on content hub items after merged into top sites

### DIFF
--- a/app/src/main/java/org/mozilla/rocket/home/contenthub/data/ContentHubRepo.kt
+++ b/app/src/main/java/org/mozilla/rocket/home/contenthub/data/ContentHubRepo.kt
@@ -36,11 +36,10 @@ class ContentHubRepo(private val appContext: Context) {
     }
 
     fun getConfiguredContentHubItems(): List<ContentHubItem>? {
-        val unreadEnabledTypes = getUnreadEnabledTypes()
         val readTypes = getReadTypes()
         val contentHubItemsJsonStr = FirebaseHelper.getFirebase().getRcString(FirebaseHelper.STR_CONTENT_HUB_ITEMS)
                 .takeIf { it.isNotEmpty() }
-        return contentHubItemsJsonStr?.jsonStringToContentHubItems(unreadEnabledTypes, readTypes)
+        return contentHubItemsJsonStr?.jsonStringToContentHubItems(readTypes)
     }
 
     fun getDefaultContentHubItems(): List<ContentHubItem>? =

--- a/app/src/main/java/org/mozilla/rocket/home/topsites/ui/SiteAdapterDelegate.kt
+++ b/app/src/main/java/org/mozilla/rocket/home/topsites/ui/SiteAdapterDelegate.kt
@@ -10,6 +10,7 @@ import android.view.View
 import androidx.core.view.ViewCompat
 import kotlinx.android.synthetic.main.item_top_site.content_image
 import kotlinx.android.synthetic.main.item_top_site.pin_indicator
+import kotlinx.android.synthetic.main.item_top_site.red_dot
 import kotlinx.android.synthetic.main.item_top_site.text
 import org.json.JSONException
 import org.json.JSONObject
@@ -73,6 +74,8 @@ class SiteViewHolder(
                     }
                     setPinColor(backgroundColor)
                 }
+                // Red dot
+                red_dot.visibility = View.GONE
 
                 itemView.setOnClickListener { homeViewModel.onTopSiteClicked(site, adapterPosition) }
                 itemView.setOnLongClickListener {
@@ -85,6 +88,14 @@ class SiteViewHolder(
                 content_image.visibility = View.VISIBLE
                 content_image.setImageResource(site.iconResId)
                 ViewCompat.setBackgroundTintList(content_image, ColorStateList.valueOf(Color.WHITE))
+                // Pin
+                PinViewWrapper(pin_indicator).visibility = View.GONE
+                // Red dot
+                red_dot.visibility = if (site.isUnread) {
+                    View.VISIBLE
+                } else {
+                    View.GONE
+                }
 
                 itemView.setOnClickListener { homeViewModel.onContentHubItemClicked(site) }
                 itemView.setOnLongClickListener(null)

--- a/app/src/main/res/layout/item_top_site.xml
+++ b/app/src/main/res/layout/item_top_site.xml
@@ -69,4 +69,15 @@
             android:backgroundTint="@color/paletteWhite100"
             android:background="@drawable/notify_pin" />
     </FrameLayout>
+
+    <View
+        android:id="@+id/red_dot"
+        android:layout_width="10dp"
+        android:layout_height="10dp"
+        android:background="@drawable/content_hub_red_dot"
+        android:elevation="4dp"
+        app:layout_constraintEnd_toEndOf="@id/content_image"
+        app:layout_constraintTop_toTopOf="@id/content_image"
+        android:visibility="gone"/>
+
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
this PR is based on #4522,  **_please only review the last commit_**

to fix #4594 

![device-2020-02-12-143356](https://user-images.githubusercontent.com/5226898/74309026-ba12f000-4da4-11ea-8d09-0f5e9e2afef3.png)
