### PR TITLE
Server Push Android Work - support data message

### DIFF
--- a/app/src/main/java/org/mozilla/focus/notification/NotificationActionBroadcastReceiver.java
+++ b/app/src/main/java/org/mozilla/focus/notification/NotificationActionBroadcastReceiver.java
@@ -24,6 +24,10 @@ import org.mozilla.focus.utils.Settings;
 import org.mozilla.focus.utils.SupportUtils;
 import org.mozilla.rocket.deeplink.task.SetDefaultBrowserTask;
 
+import static org.mozilla.focus.notification.RocketMessagingService.STR_PUSH_COMMAND;
+import static org.mozilla.focus.notification.RocketMessagingService.STR_PUSH_DEEP_LINK;
+import static org.mozilla.focus.notification.RocketMessagingService.STR_PUSH_OPEN_URL;
+
 // This class handles all click/actions users performed on a notification.
 // This ensures that all telemetry works for action/click are in one place.
 // The UI code will be responsible for telemetry work for displaying the notifications.
@@ -59,9 +63,9 @@ public class NotificationActionBroadcastReceiver extends BroadcastReceiver {
         } else if (bundle.getBoolean(IntentUtils.EXTRA_NOTIFICATION_CLICK_NOTIFICATION)) {
             nexStep = new Intent();
             nexStep.setClassName(context, AppConstants.LAUNCHER_ACTIVITY_ALIAS);
-            nexStep.putExtra(FirebaseMessagingServiceWrapper.PUSH_OPEN_URL, intent.getStringExtra(IntentUtils.EXTRA_NOTIFICATION_OPEN_URL));
-            nexStep.putExtra(FirebaseMessagingServiceWrapper.PUSH_COMMAND, intent.getStringExtra(IntentUtils.EXTRA_NOTIFICATION_COMMAND));
-            nexStep.putExtra(FirebaseMessagingServiceWrapper.PUSH_DEEP_LINK, intent.getStringExtra(IntentUtils.EXTRA_NOTIFICATION_DEEP_LINK));
+            nexStep.putExtra(STR_PUSH_OPEN_URL, intent.getStringExtra(IntentUtils.EXTRA_NOTIFICATION_OPEN_URL));
+            nexStep.putExtra(STR_PUSH_COMMAND, intent.getStringExtra(IntentUtils.EXTRA_NOTIFICATION_COMMAND));
+            nexStep.putExtra(STR_PUSH_DEEP_LINK, intent.getStringExtra(IntentUtils.EXTRA_NOTIFICATION_DEEP_LINK));
 
             String source = bundle.getString(IntentUtils.EXTRA_NOTIFICATION_NOTIFICATION_SOURCE);
             String link = bundle.getString(IntentUtils.EXTRA_NOTIFICATION_LINK, "");

--- a/app/src/main/java/org/mozilla/focus/notification/NotificationScheduleWorker.kt
+++ b/app/src/main/java/org/mozilla/focus/notification/NotificationScheduleWorker.kt
@@ -15,7 +15,7 @@ import org.mozilla.focus.notification.RocketMessagingService.Companion.STR_PUSH_
 class NotificationScheduleWorker(val context: Context, workerParams: WorkerParameters) : Worker(context, workerParams) {
 
     companion object {
-        private const val TAG = "ServerPush"
+        private const val TAG = "FCM_WORKER"
     }
 
     override fun doWork(): Result {

--- a/app/src/main/java/org/mozilla/focus/notification/NotificationScheduleWorker.kt
+++ b/app/src/main/java/org/mozilla/focus/notification/NotificationScheduleWorker.kt
@@ -1,14 +1,8 @@
 package org.mozilla.focus.notification
 
-import android.app.PendingIntent
 import android.content.Context
-import android.graphics.Bitmap
-import androidx.core.app.NotificationCompat
 import androidx.work.Worker
 import androidx.work.WorkerParameters
-import com.bumptech.glide.Glide
-import com.bumptech.glide.request.target.SimpleTarget
-import com.bumptech.glide.request.transition.Transition
 import org.mozilla.focus.notification.RocketMessagingService.Companion.STR_DATA_MSG_BODY
 import org.mozilla.focus.notification.RocketMessagingService.Companion.STR_DATA_MSG_IMAGE_URL
 import org.mozilla.focus.notification.RocketMessagingService.Companion.STR_DATA_MSG_TITLE
@@ -16,9 +10,6 @@ import org.mozilla.focus.notification.RocketMessagingService.Companion.STR_MESSA
 import org.mozilla.focus.notification.RocketMessagingService.Companion.STR_PUSH_COMMAND
 import org.mozilla.focus.notification.RocketMessagingService.Companion.STR_PUSH_DEEP_LINK
 import org.mozilla.focus.notification.RocketMessagingService.Companion.STR_PUSH_OPEN_URL
-import org.mozilla.focus.telemetry.TelemetryWrapper
-import org.mozilla.focus.utils.IntentUtils
-import org.mozilla.threadutils.ThreadUtils
 
 class NotificationScheduleWorker(val context: Context, workerParams: WorkerParameters) : Worker(context, workerParams) {
 
@@ -27,63 +18,13 @@ class NotificationScheduleWorker(val context: Context, workerParams: WorkerParam
         val title = inputData.getString(STR_DATA_MSG_TITLE)
         val body = inputData.getString(STR_DATA_MSG_BODY)
 
-
         val openUrl = inputData.getString(STR_PUSH_OPEN_URL)
         val pushCommand = inputData.getString(STR_PUSH_COMMAND)
         val deepLink = inputData.getString(STR_PUSH_DEEP_LINK)
-        val link = openUrl ?: pushCommand ?: deepLink ?: ""
         val imageUrl = inputData.getString(STR_DATA_MSG_IMAGE_URL)
 
-
-        val pendingIntent = getClickPendingIntent(
-                applicationContext,
-                messageId,
-                openUrl,
-                pushCommand,
-                deepLink
-        )
-        val builder = NotificationUtil.importantBuilder(context).setContentIntent(pendingIntent)
-        title?.let { builder.setContentTitle(it) }
-        body?.let { builder.setContentText(it) }
-        addDeleteTelemetry(applicationContext, builder, messageId, link)
-
-        if (!imageUrl.isNullOrEmpty()) {
-            ThreadUtils.postToMainThread {
-                Glide.with(applicationContext)
-                        .asBitmap()
-                        .load(imageUrl)
-                        .into(object : SimpleTarget<Bitmap?>() {
-                            override fun onResourceReady(resource: Bitmap?, transition: Transition<in Bitmap?>?) {
-                                builder.setLargeIcon(resource)
-                                builder.setStyle(NotificationCompat.BigPictureStyle().bigPicture(resource))
-
-                                NotificationUtil.sendNotification(context, NotificationId.FIREBASE_AD_HOC, builder)
-                                TelemetryWrapper.showNotification(link, messageId)
-                            }
-                        })
-            }
-        } else {
-            NotificationUtil.sendNotification(context, NotificationId.FIREBASE_AD_HOC, builder)
-            TelemetryWrapper.showNotification(link, messageId)
-        }
+        RocketMessagingService.handlePushMessage(context.applicationContext, messageId, openUrl, pushCommand, deepLink, title, body, imageUrl)
 
         return Result.success()
-    }
-
-    private fun getClickPendingIntent(appContext: Context, messageId: String?, openUrl: String?, command: String?, deepLink: String?): PendingIntent { // RocketLauncherActivity will handle this intent
-        val clickIntent = IntentUtils.genFirebaseNotificationClickForBroadcastReceiver(
-                appContext,
-                messageId,
-                openUrl,
-                command,
-                deepLink
-        )
-        return PendingIntent.getBroadcast(appContext, RocketMessagingService.REQUEST_CODE_CLICK_NOTIFICATION, clickIntent, PendingIntent.FLAG_ONE_SHOT)
-    }
-
-    private fun addDeleteTelemetry(appContext: Context, builder: NotificationCompat.Builder, messageId: String?, link: String?) {
-        val intent = IntentUtils.genDeleteFirebaseNotificationActionForBroadcastReceiver(appContext, messageId, link)
-        val pendingIntent = PendingIntent.getBroadcast(appContext, RocketMessagingService.REQUEST_CODE_DELETE_NOTIFICATION, intent, PendingIntent.FLAG_ONE_SHOT)
-        builder.setDeleteIntent(pendingIntent)
     }
 }

--- a/app/src/main/java/org/mozilla/focus/notification/NotificationScheduleWorker.kt
+++ b/app/src/main/java/org/mozilla/focus/notification/NotificationScheduleWorker.kt
@@ -1,0 +1,89 @@
+package org.mozilla.focus.notification
+
+import android.app.PendingIntent
+import android.content.Context
+import android.graphics.Bitmap
+import androidx.core.app.NotificationCompat
+import androidx.work.Worker
+import androidx.work.WorkerParameters
+import com.bumptech.glide.Glide
+import com.bumptech.glide.request.target.SimpleTarget
+import com.bumptech.glide.request.transition.Transition
+import org.mozilla.focus.notification.RocketMessagingService.Companion.STR_DATA_MSG_BODY
+import org.mozilla.focus.notification.RocketMessagingService.Companion.STR_DATA_MSG_IMAGE_URL
+import org.mozilla.focus.notification.RocketMessagingService.Companion.STR_DATA_MSG_TITLE
+import org.mozilla.focus.notification.RocketMessagingService.Companion.STR_MESSAGE_ID
+import org.mozilla.focus.notification.RocketMessagingService.Companion.STR_PUSH_COMMAND
+import org.mozilla.focus.notification.RocketMessagingService.Companion.STR_PUSH_DEEP_LINK
+import org.mozilla.focus.notification.RocketMessagingService.Companion.STR_PUSH_OPEN_URL
+import org.mozilla.focus.telemetry.TelemetryWrapper
+import org.mozilla.focus.utils.IntentUtils
+import org.mozilla.threadutils.ThreadUtils
+
+class NotificationScheduleWorker(val context: Context, workerParams: WorkerParameters) : Worker(context, workerParams) {
+
+    override fun doWork(): Result {
+        val messageId = inputData.getString(STR_MESSAGE_ID)
+        val title = inputData.getString(STR_DATA_MSG_TITLE)
+        val body = inputData.getString(STR_DATA_MSG_BODY)
+
+
+        val openUrl = inputData.getString(STR_PUSH_OPEN_URL)
+        val pushCommand = inputData.getString(STR_PUSH_COMMAND)
+        val deepLink = inputData.getString(STR_PUSH_DEEP_LINK)
+        val link = openUrl ?: pushCommand ?: deepLink ?: ""
+        val imageUrl = inputData.getString(STR_DATA_MSG_IMAGE_URL)
+
+
+        val pendingIntent = getClickPendingIntent(
+                applicationContext,
+                messageId,
+                openUrl,
+                pushCommand,
+                deepLink
+        )
+        val builder = NotificationUtil.importantBuilder(context).setContentIntent(pendingIntent)
+        title?.let { builder.setContentTitle(it) }
+        body?.let { builder.setContentText(it) }
+        addDeleteTelemetry(applicationContext, builder, messageId, link)
+
+        if (!imageUrl.isNullOrEmpty()) {
+            ThreadUtils.postToMainThread {
+                Glide.with(applicationContext)
+                        .asBitmap()
+                        .load(imageUrl)
+                        .into(object : SimpleTarget<Bitmap?>() {
+                            override fun onResourceReady(resource: Bitmap?, transition: Transition<in Bitmap?>?) {
+                                builder.setLargeIcon(resource)
+                                builder.setStyle(NotificationCompat.BigPictureStyle().bigPicture(resource))
+
+                                NotificationUtil.sendNotification(context, NotificationId.FIREBASE_AD_HOC, builder)
+                                TelemetryWrapper.showNotification(link, messageId)
+                            }
+                        })
+            }
+        } else {
+            NotificationUtil.sendNotification(context, NotificationId.FIREBASE_AD_HOC, builder)
+            TelemetryWrapper.showNotification(link, messageId)
+        }
+
+        return Result.success()
+    }
+
+    private fun getClickPendingIntent(appContext: Context, messageId: String?, openUrl: String?, command: String?, deepLink: String?): PendingIntent { // RocketLauncherActivity will handle this intent
+        val clickIntent = IntentUtils.genFirebaseNotificationClickForBroadcastReceiver(
+                appContext,
+                messageId,
+                openUrl,
+                command,
+                deepLink
+        )
+        return PendingIntent.getBroadcast(appContext, RocketMessagingService.REQUEST_CODE_CLICK_NOTIFICATION, clickIntent, PendingIntent.FLAG_ONE_SHOT)
+    }
+
+    private fun addDeleteTelemetry(appContext: Context, builder: NotificationCompat.Builder, messageId: String?, link: String?) {
+        val intent = IntentUtils.genDeleteFirebaseNotificationActionForBroadcastReceiver(appContext, messageId, link)
+        val pendingIntent = PendingIntent.getBroadcast(appContext, RocketMessagingService.REQUEST_CODE_DELETE_NOTIFICATION, intent, PendingIntent.FLAG_ONE_SHOT)
+        builder.setDeleteIntent(pendingIntent)
+    }
+}

--- a/app/src/main/java/org/mozilla/focus/notification/NotificationScheduleWorker.kt
+++ b/app/src/main/java/org/mozilla/focus/notification/NotificationScheduleWorker.kt
@@ -1,6 +1,7 @@
 package org.mozilla.focus.notification
 
 import android.content.Context
+import android.util.Log
 import androidx.work.Worker
 import androidx.work.WorkerParameters
 import org.mozilla.focus.notification.RocketMessagingService.Companion.STR_DATA_MSG_BODY
@@ -13,9 +14,14 @@ import org.mozilla.focus.notification.RocketMessagingService.Companion.STR_PUSH_
 
 class NotificationScheduleWorker(val context: Context, workerParams: WorkerParameters) : Worker(context, workerParams) {
 
+    companion object {
+        private const val TAG = "ServerPush"
+    }
+
     override fun doWork(): Result {
         val messageId = inputData.getString(STR_MESSAGE_ID)
         val title = inputData.getString(STR_DATA_MSG_TITLE)
+        Log.d(TAG, "Displaying title[$title] with messageId[$messageId]")
         val body = inputData.getString(STR_DATA_MSG_BODY)
 
         val openUrl = inputData.getString(STR_PUSH_OPEN_URL)

--- a/app/src/main/java/org/mozilla/focus/notification/RocketMessagingService.kt
+++ b/app/src/main/java/org/mozilla/focus/notification/RocketMessagingService.kt
@@ -25,7 +25,6 @@ import mozilla.components.concept.fetch.Request
 import mozilla.components.concept.fetch.interceptor.withInterceptors
 import mozilla.components.lib.fetch.httpurlconnection.HttpURLConnectionClient
 import org.mozilla.focus.telemetry.TelemetryWrapper
-import org.mozilla.focus.telemetry.TelemetryWrapper.getNotification
 import org.mozilla.focus.telemetry.TelemetryWrapper.isTelemetryEnabled
 import org.mozilla.focus.utils.FirebaseHelper
 import org.mozilla.focus.utils.IntentUtils
@@ -48,6 +47,9 @@ class RocketMessagingService : FirebaseMessagingServiceWrapper() {
         val deepLink = parseDeepLink(data)
         Log.d(TAG, "onNotificationMessage messageId:$$messageId ")
 
+        val link = parseLink(openUrl, pushCommand, deepLink)
+        TelemetryWrapper.getNotification(link, messageId)
+
         handlePushMessage(applicationContext, messageId, openUrl, pushCommand, deepLink, title, body, imageUrl)
     }
 
@@ -68,6 +70,9 @@ class RocketMessagingService : FirebaseMessagingServiceWrapper() {
         val deepLink = parseDeepLink(data)
         val displayType = parseDisplayType(data)
         val displayTimestamp = parseDisplayTimestamp(data)
+
+        val link = parseLink(openUrl, pushCommand, deepLink)
+        TelemetryWrapper.getNotification(link, messageId)
 
         if (messageId == null || title == null || body == null || displayTimestamp == null || displayType == null) {
             Log.d(TAG, "onDataMessage failed. Required field missing")
@@ -189,8 +194,6 @@ class RocketMessagingService : FirebaseMessagingServiceWrapper() {
             body?.let { builder.setContentText(it) }
 
             val link = parseLink(openUrl, pushCommand, deepLink)
-
-            getNotification(link, messageId)
 
             if (!isTelemetryEnabled(applicationContext)) {
                 return

--- a/app/src/main/java/org/mozilla/focus/notification/RocketMessagingService.kt
+++ b/app/src/main/java/org/mozilla/focus/notification/RocketMessagingService.kt
@@ -53,9 +53,10 @@ class RocketMessagingService : FirebaseMessagingServiceWrapper() {
 
     override fun onDataMessage(data: MutableMap<String, String>) {
 
-        val serverPushDisabled = FirebaseHelper.getFirebase().getRcBoolean(BOOL_IS_SERVER_PUSH_DISABLED)
-        Log.d(TAG, "onDataMessage disabled:$$serverPushDisabled ")
-        if (serverPushDisabled) {
+        val serverPushEnabled = FirebaseHelper.getFirebase().getRcBoolean(BOOL_IS_SERVER_PUSH_ENABLED)
+        val serverPushDebugging = Settings.getInstance(applicationContext).isServerPushDebugging
+        Log.d(TAG, "onDataMessage enabled:$$serverPushEnabled ")
+        if (!serverPushEnabled && !serverPushDebugging) {
             // return early if we pref off this feature in Firebase Remote Config
             return
         }
@@ -139,7 +140,7 @@ class RocketMessagingService : FirebaseMessagingServiceWrapper() {
 
         private const val TAG = "RocketMessagingService"
         private const val STR_USER_TOKEN_API = "str_user_token_api"
-        private const val BOOL_IS_SERVER_PUSH_DISABLED = "bool_is_server_push_disabled"
+        private const val BOOL_IS_SERVER_PUSH_ENABLED = "bool_is_server_push_enabled"
 
         fun scheduleNotification(applicationContext: Context, messageId: String, imageUrl: String?, title: String?, body: String?, openUrl: String?, pushCommand: String?, deepLink: String?, displayTimestamp: Long) {
 

--- a/app/src/main/java/org/mozilla/focus/notification/RocketMessagingService.kt
+++ b/app/src/main/java/org/mozilla/focus/notification/RocketMessagingService.kt
@@ -55,7 +55,7 @@ class RocketMessagingService : FirebaseMessagingServiceWrapper() {
 
         val serverPushEnabled = FirebaseHelper.getFirebase().getRcBoolean(BOOL_IS_SERVER_PUSH_ENABLED)
         val serverPushDebugging = Settings.getInstance(applicationContext).isServerPushDebugging
-        Log.d(TAG, "onDataMessage enabled:$$serverPushEnabled ")
+        Log.d(TAG, "onDataMessage enabled:$serverPushEnabled ")
         if (!serverPushEnabled && !serverPushDebugging) {
             // return early if we pref off this feature in Firebase Remote Config
             return
@@ -277,6 +277,7 @@ class RocketMessagingService : FirebaseMessagingServiceWrapper() {
 
         @WorkerThread
         private fun sendRegistrationToServer(applicationContext: Context, fbUid: String, fcmToken: String) {
+            Log.d(TAG, "sendRegistrationToServer with token")
             val telemetryClientId = TelemetryHolder.get().clientId
             if (telemetryClientId == null) {
                 Log.w(TAG, "telemetryClientId is null")
@@ -308,6 +309,8 @@ class RocketMessagingService : FirebaseMessagingServiceWrapper() {
                             if (it.status == 200) {
                                 Settings.getInstance(applicationContext).setHashedFcmToken(fcmToken)
                                 Log.d(TAG, "FCM Token uploaded: ${fcmToken.hashCode()}")
+                            } else {
+                                Log.d(TAG, "FCM Token uploaded status[${it.status}]: [${it.body}]")
                             }
                         }
             } catch (e: IOException) {

--- a/app/src/main/java/org/mozilla/focus/notification/RocketMessagingService.kt
+++ b/app/src/main/java/org/mozilla/focus/notification/RocketMessagingService.kt
@@ -138,7 +138,7 @@ class RocketMessagingService : FirebaseMessagingServiceWrapper() {
         const val LONG_DATA_MSG_DISPLAY_TIMESTAMP = "display_timestamp"
         const val STR_DATA_MSG_IMAGE_URL = "image_url"
 
-        private const val TAG = "RocketMessagingService"
+        private const val TAG = "FCM_SERVICE"
         private const val STR_USER_TOKEN_API = "str_user_token_api"
         private const val BOOL_IS_SERVER_PUSH_ENABLED = "bool_is_server_push_enabled"
 

--- a/app/src/main/java/org/mozilla/focus/notification/RocketMessagingService.kt
+++ b/app/src/main/java/org/mozilla/focus/notification/RocketMessagingService.kt
@@ -21,7 +21,7 @@ import org.mozilla.threadutils.ThreadUtils
 // Prov
 class RocketMessagingService : FirebaseMessagingServiceWrapper() {
     //
-    override fun onRemoteMessage(intent: Intent, title: String?, body: String?) {
+    override fun onNotificationMessage(intent: Intent, title: String?, body: String?) {
         val messageId = parseMessageId(intent)
         val link = parseLink(intent)
         getNotification(link, messageId)

--- a/app/src/main/java/org/mozilla/focus/notification/RocketMessagingService.kt
+++ b/app/src/main/java/org/mozilla/focus/notification/RocketMessagingService.kt
@@ -9,6 +9,7 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.util.Log
 import android.webkit.URLUtil
+import androidx.annotation.WorkerThread
 import androidx.core.app.NotificationCompat
 import androidx.work.Data
 import androidx.work.OneTimeWorkRequest
@@ -16,11 +17,23 @@ import androidx.work.WorkManager
 import com.bumptech.glide.Glide
 import com.bumptech.glide.request.target.SimpleTarget
 import com.bumptech.glide.request.transition.Transition
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import mozilla.components.concept.fetch.MutableHeaders
+import mozilla.components.concept.fetch.Request
+import mozilla.components.concept.fetch.interceptor.withInterceptors
+import mozilla.components.lib.fetch.httpurlconnection.HttpURLConnectionClient
 import org.mozilla.focus.telemetry.TelemetryWrapper
 import org.mozilla.focus.telemetry.TelemetryWrapper.getNotification
 import org.mozilla.focus.telemetry.TelemetryWrapper.isTelemetryEnabled
+import org.mozilla.focus.utils.FirebaseHelper
 import org.mozilla.focus.utils.IntentUtils
+import org.mozilla.focus.utils.Settings
+import org.mozilla.rocket.msrp.data.LoggingInterceptor
+import org.mozilla.telemetry.TelemetryHolder
 import org.mozilla.threadutils.ThreadUtils
+import java.io.IOException
 import java.util.concurrent.TimeUnit
 
 /**
@@ -33,6 +46,7 @@ class RocketMessagingService : FirebaseMessagingServiceWrapper() {
         val openUrl = parseOpenUrl(data)
         val pushCommand = parseCommand(data)
         val deepLink = parseDeepLink(data)
+        Log.d(TAG, "onNotificationMessage messageId:$$messageId ")
 
         handlePushMessage(applicationContext, messageId, openUrl, pushCommand, deepLink, title, body, imageUrl)
     }
@@ -49,29 +63,19 @@ class RocketMessagingService : FirebaseMessagingServiceWrapper() {
         val displayTimestamp = parseDisplayTimestamp(data)
 
         if (messageId == null || title == null || body == null || displayTimestamp == null || displayType == null) {
+            Log.d(TAG, "onDataMessage failed. Required field missing")
             return
         }
 
-        val imageUri = parseImageUrl(data)
+        val imageUrl = parseImageUrl(data)
 
-        scheduleNotification(applicationContext, messageId, imageUri, title, body, openUrl, pushCommand, deepLink, displayTimestamp)
+        scheduleNotification(applicationContext, messageId, imageUrl, title, body, openUrl, pushCommand, deepLink, displayTimestamp)
     }
 
     override fun onNewToken(token: String) {
         super.onNewToken(token)
-        sendRegistrationToServer(token)
-    }
-
-    private fun sendRegistrationToServer(token: String) {
-        Log.d("FirebaseAaaa", "[$token]----")
-//        place holder for the server side
-//        HttpURLConnectionClient()
-//                .withInterceptors(LoggingInterceptor())
-//                .fetch(Request(
-//                        url = ""
-//                )).use {
-//                    Log.d("FirebaseAaaa", "[$token]----${it.body.toString()}")
-//                }
+        Log.d(TAG, "onNewToken")
+        handleNewToken(applicationContext, token)
     }
 
     private fun parseMessageId(data: Map<String, String>): String? {
@@ -125,13 +129,13 @@ class RocketMessagingService : FirebaseMessagingServiceWrapper() {
         const val STR_DATA_MSG_BODY = "body"
         const val STR_DATA_MSG_DISPLAY_TYPE = "display_type"
         const val LONG_DATA_MSG_DISPLAY_TIMESTAMP = "display_timestamp"
-        const val STR_DATA_MSG_IMAGE_URL = "image_uri"
+        const val STR_DATA_MSG_IMAGE_URL = "image_url"
 
-        fun scheduleNotification(applicationContext: Context, messageId: String, imageUri: String?, title: String?, body: String?, openUrl: String?, pushCommand: String?, deepLink: String?, displayTimestamp: Long) {
+        private const val TAG = "RocketMessagingService"
+        private const val STR_USER_TOKEN_API = "str_user_token_api"
 
-            if (imageUri != null && !URLUtil.isValidUrl(imageUri)) {
-                return
-            }
+        fun scheduleNotification(applicationContext: Context, messageId: String, imageUrl: String?, title: String?, body: String?, openUrl: String?, pushCommand: String?, deepLink: String?, displayTimestamp: Long) {
+
             val inputDataBuilder = Data.Builder()
                     .putString(STR_MESSAGE_ID, messageId)
                     .putString(STR_DATA_MSG_TITLE, title)
@@ -140,14 +144,23 @@ class RocketMessagingService : FirebaseMessagingServiceWrapper() {
                     .putString(STR_PUSH_COMMAND, pushCommand)
                     .putString(STR_PUSH_DEEP_LINK, deepLink)
 
-            if ((imageUri != null)) {
-                inputDataBuilder.putString(STR_DATA_MSG_IMAGE_URL, imageUri)
+            // only allow valid urls
+            if (imageUrl != null && URLUtil.isValidUrl(imageUrl)) {
+                Log.d(TAG, "Setting imageUrl")
+                inputDataBuilder.putString(STR_DATA_MSG_IMAGE_URL, imageUrl)
             }
 
+            val delay = displayTimestamp - System.currentTimeMillis()
+            if (delay < 0) {
+                Log.d(TAG, "Request delay [$delay] ms was due")
+                return // if the message comes late, ignore it.
+            }
+
+            Log.d(TAG, "Schedule display notification [$title] from server [$delay] ms later.")
             val request =
                     OneTimeWorkRequest.Builder(NotificationScheduleWorker::class.java)
                             .setInputData(inputDataBuilder.build())
-                            .setInitialDelay(displayTimestamp - System.currentTimeMillis(), TimeUnit.MILLISECONDS)
+                            .setInitialDelay(delay, TimeUnit.MILLISECONDS)
                             .addTag(messageId)
                             .build()
 
@@ -224,6 +237,74 @@ class RocketMessagingService : FirebaseMessagingServiceWrapper() {
             val intent = IntentUtils.genDeleteFirebaseNotificationActionForBroadcastReceiver(appContext, messageId, link)
             val pendingIntent = PendingIntent.getBroadcast(appContext, RocketMessagingService.REQUEST_CODE_DELETE_NOTIFICATION, intent, PendingIntent.FLAG_ONE_SHOT)
             builder.setDeleteIntent(pendingIntent)
+        }
+
+        fun checkFcmTokenUploaded(applicationContext: Context) {
+            val hashedFcmToken = Settings.getInstance(applicationContext).hashedFcmToken
+            val currentFcmToken = FirebaseHelper.getFirebase().getFcmToken()
+
+            if (currentFcmToken == null) {
+                Log.w(TAG, "currentFcmToken is null. Wait for it and retry")
+                return
+            }
+            if (hashedFcmToken != currentFcmToken.hashCode()) {
+                Log.d(TAG, "handleNewToken....")
+                handleNewToken(applicationContext, currentFcmToken)
+            } else {
+                Log.w(TAG, "token not changed")
+            }
+        }
+
+        private fun handleNewToken(applicationContext: Context, token: String) {
+            FirebaseHelper.getFirebase().getUserToken {
+                runBlocking {
+                    withContext(Dispatchers.IO) {
+                        it?.apply {
+                            sendRegistrationToServer(applicationContext, this, token)
+                        }
+                    }
+                }
+            }
+        }
+
+        @WorkerThread
+        private fun sendRegistrationToServer(applicationContext: Context, fbUid: String, fcmToken: String) {
+            val telemetryClientId = TelemetryHolder.get().clientId
+            if (telemetryClientId == null) {
+                Log.w(TAG, "telemetryClientId is null")
+                return
+            }
+
+            // something like //"http://10.0.2.2:8080/api/v1/user/token"
+            val userTokenApiUrl = FirebaseHelper.getFirebase().getRcString(STR_USER_TOKEN_API)
+            if (userTokenApiUrl.isEmpty()) {
+                Log.w(TAG, "userTokenApiUrl is empty. Wait for RemoteConfig and retry")
+                return
+            }
+            Log.d(TAG, "userTokenApiUrl = $userTokenApiUrl")
+            val request = Request(
+                    url = userTokenApiUrl,
+                    headers = MutableHeaders(
+                            "Authorization" to "Bearer $fbUid"
+                    ),
+                    body = Request.Body.fromParamsForFormUrlEncoded(
+                            "telemetry_client_id" to telemetryClientId,
+                            "fcm_token" to fcmToken
+                    )
+            )
+            try {
+
+                HttpURLConnectionClient()
+                        .withInterceptors(LoggingInterceptor())
+                        .fetch(request).use {
+                            if (it.status == 200) {
+                                Settings.getInstance(applicationContext).setHashedFcmToken(fcmToken)
+                                Log.d(TAG, "FCM Token uploaded: ${fcmToken.hashCode()}")
+                            }
+                        }
+            } catch (e: IOException) {
+                Log.e(TAG, "FCM Token upload ERROR: [${fcmToken.hashCode()}] with [${e.localizedMessage}]")
+            }
         }
     }
 }

--- a/app/src/main/java/org/mozilla/focus/notification/RocketMessagingService.kt
+++ b/app/src/main/java/org/mozilla/focus/notification/RocketMessagingService.kt
@@ -53,6 +53,12 @@ class RocketMessagingService : FirebaseMessagingServiceWrapper() {
 
     override fun onDataMessage(data: MutableMap<String, String>) {
 
+        val serverPushDisabled = FirebaseHelper.getFirebase().getRcBoolean(BOOL_IS_SERVER_PUSH_DISABLED)
+        Log.d(TAG, "onDataMessage disabled:$$serverPushDisabled ")
+        if (serverPushDisabled) {
+            // return early if we pref off this feature in Firebase Remote Config
+            return
+        }
         val messageId = parseMessageId(data)
         val title = parseTitle(data)
         val body = parseBody(data)
@@ -133,6 +139,7 @@ class RocketMessagingService : FirebaseMessagingServiceWrapper() {
 
         private const val TAG = "RocketMessagingService"
         private const val STR_USER_TOKEN_API = "str_user_token_api"
+        private const val BOOL_IS_SERVER_PUSH_DISABLED = "bool_is_server_push_disabled"
 
         fun scheduleNotification(applicationContext: Context, messageId: String, imageUrl: String?, title: String?, body: String?, openUrl: String?, pushCommand: String?, deepLink: String?, displayTimestamp: Long) {
 

--- a/app/src/main/java/org/mozilla/focus/utils/FirebaseHelper.kt
+++ b/app/src/main/java/org/mozilla/focus/utils/FirebaseHelper.kt
@@ -12,6 +12,7 @@ import android.util.Log
 import androidx.annotation.VisibleForTesting
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import org.mozilla.focus.R
+import org.mozilla.focus.notification.RocketMessagingService
 import org.mozilla.focus.screenshot.ScreenshotManager
 import org.mozilla.rocket.periodic.FirstLaunchWorker
 import org.mozilla.rocket.shopping.search.data.ShoppingSearchRemoteDataSource.Companion.RC_KEY_ENABLE_SHOPPING_SEARCH
@@ -268,6 +269,7 @@ object FirebaseHelper {
     @JvmStatic
     fun initUserState(activity: Activity) {
         firebaseContract.initUserState(activity)
+        RocketMessagingService.checkFcmTokenUploaded(activity.applicationContext)
     }
 
     @JvmStatic

--- a/app/src/main/java/org/mozilla/focus/utils/Settings.java
+++ b/app/src/main/java/org/mozilla/focus/utils/Settings.java
@@ -180,6 +180,17 @@ public class Settings {
                 () -> preferences.getInt(getPreferenceKey(R.string.pref_int_fcm_token), 0));
     }
 
+    public void setServerPushDebugging(boolean enable) {
+        preferences.edit()
+                .putBoolean(getPreferenceKey(R.string.pre_bool_is_server_push_enabled), enable)
+                .apply();
+    }
+
+    public Boolean isServerPushDebugging() {
+        return StrictModeViolation.tempGrant(builder -> builder.permitDiskReads().permitDiskWrites(),
+                () -> preferences.getBoolean(getPreferenceKey(R.string.pre_bool_is_server_push_enabled), false));
+    }
+
     public void setRateAppDialogDidShow() {
         preferences.edit()
                 .putBoolean(getPreferenceKey(R.string.pref_key_did_show_rate_app_dialog), true)

--- a/app/src/main/java/org/mozilla/focus/utils/Settings.java
+++ b/app/src/main/java/org/mozilla/focus/utils/Settings.java
@@ -19,6 +19,7 @@ import org.mozilla.focus.provider.SettingPreferenceWrapper;
 import org.mozilla.focus.search.SearchEngine;
 import org.mozilla.rocket.preference.SharedPreferenceLiveData;
 import org.mozilla.rocket.preference.SharedPreferenceLiveDataKt;
+import org.mozilla.strictmodeviolator.StrictModeViolation;
 
 import java.util.Set;
 
@@ -166,6 +167,17 @@ public class Settings {
 
     public boolean didShowRateAppDialog() {
         return preferences.getBoolean(getPreferenceKey(R.string.pref_key_did_show_rate_app_dialog), DID_SHOW_RATE_APP_DEFAULT);
+    }
+
+    public void setHashedFcmToken(String fcmToken) {
+        preferences.edit()
+                .putInt(getPreferenceKey(R.string.pref_int_fcm_token), fcmToken.hashCode())
+                .apply();
+    }
+
+    public int getHashedFcmToken() {
+        return StrictModeViolation.<Integer>tempGrant(builder -> builder.permitDiskReads().permitDiskWrites(),
+                () -> preferences.getInt(getPreferenceKey(R.string.pref_int_fcm_token), 0));
     }
 
     public void setRateAppDialogDidShow() {

--- a/app/src/main/java/org/mozilla/rocket/component/LaunchIntentDispatcher.kt
+++ b/app/src/main/java/org/mozilla/rocket/component/LaunchIntentDispatcher.kt
@@ -90,7 +90,7 @@ class LaunchIntentDispatcher {
                 return Action.HANDLED
             }
             /**
-             * This extra is passed by the Notification (either [RocketMessagingService.onRemoteMessage] or System tray
+             * This extra is passed by the Notification (either [RocketMessagingService.onNotificationMessage] or System tray
              * if we have this extra, we want to show this url in a new tab
              */
             intent.getStringExtra(PUSH_OPEN_URL)?.run {
@@ -102,7 +102,7 @@ class LaunchIntentDispatcher {
             }
 
             /**
-             * This extra is passed by the Notification (either [RocketMessagingService.onRemoteMessage] or System tray
+             * This extra is passed by the Notification (either [RocketMessagingService.onNotificationMessage] or System tray
              *  Called by the internal app, doesn't count as a launch event
              * */
             intent.getStringExtra(PUSH_COMMAND)?.apply {
@@ -119,7 +119,7 @@ class LaunchIntentDispatcher {
                 }
             }
             /**
-             * This extra is passed by the Notification (either [RocketMessagingService.onRemoteMessage] or System tray
+             * This extra is passed by the Notification (either [RocketMessagingService.onNotificationMessage] or System tray
              * if we have this extra, we want to enable the deep link
              */
             intent.getStringExtra(PUSH_DEEP_LINK)?.let {

--- a/app/src/main/java/org/mozilla/rocket/component/LaunchIntentDispatcher.kt
+++ b/app/src/main/java/org/mozilla/rocket/component/LaunchIntentDispatcher.kt
@@ -8,10 +8,10 @@ import org.mozilla.focus.BuildConfig.FXA_EMAIL_VERIFY_URL
 import org.mozilla.focus.activity.InfoActivity
 import org.mozilla.focus.activity.MainActivity
 import org.mozilla.focus.activity.SettingsActivity
-import org.mozilla.focus.notification.FirebaseMessagingServiceWrapper.Companion.PUSH_COMMAND
-import org.mozilla.focus.notification.FirebaseMessagingServiceWrapper.Companion.PUSH_DEEP_LINK
-import org.mozilla.focus.notification.FirebaseMessagingServiceWrapper.Companion.PUSH_OPEN_URL
 import org.mozilla.focus.notification.RocketMessagingService
+import org.mozilla.focus.notification.RocketMessagingService.Companion.STR_PUSH_COMMAND
+import org.mozilla.focus.notification.RocketMessagingService.Companion.STR_PUSH_DEEP_LINK
+import org.mozilla.focus.notification.RocketMessagingService.Companion.STR_PUSH_OPEN_URL
 import org.mozilla.focus.telemetry.TelemetryWrapper
 import org.mozilla.focus.utils.IntentUtils
 import org.mozilla.focus.utils.SupportUtils
@@ -93,7 +93,7 @@ class LaunchIntentDispatcher {
              * This extra is passed by the Notification (either [RocketMessagingService.onNotificationMessage] or System tray
              * if we have this extra, we want to show this url in a new tab
              */
-            intent.getStringExtra(PUSH_OPEN_URL)?.run {
+            intent.getStringExtra(STR_PUSH_OPEN_URL)?.run {
 
                 intent.data = Uri.parse(this)
                 intent.action = Intent.ACTION_VIEW
@@ -105,7 +105,7 @@ class LaunchIntentDispatcher {
              * This extra is passed by the Notification (either [RocketMessagingService.onNotificationMessage] or System tray
              *  Called by the internal app, doesn't count as a launch event
              * */
-            intent.getStringExtra(PUSH_COMMAND)?.apply {
+            intent.getStringExtra(STR_PUSH_COMMAND)?.apply {
                 when (this) {
                     Command.SET_DEFAULT.value -> {
                         if (!IntentUtils.openDefaultAppsSettings(context)) {
@@ -122,7 +122,7 @@ class LaunchIntentDispatcher {
              * This extra is passed by the Notification (either [RocketMessagingService.onNotificationMessage] or System tray
              * if we have this extra, we want to enable the deep link
              */
-            intent.getStringExtra(PUSH_DEEP_LINK)?.let {
+            intent.getStringExtra(STR_PUSH_DEEP_LINK)?.let {
                 val deepLinkType = DeepLinkType.parse(it)
                 return if (deepLinkType != DeepLinkType.NOT_SUPPORT) {
                     deepLinkType.execute(context)
@@ -177,12 +177,12 @@ class LaunchIntentDispatcher {
         }
 
         private fun parseLink(intent: Intent): String? {
-            var link: String? = intent.getStringExtra(PUSH_OPEN_URL)
+            var link: String? = intent.getStringExtra(STR_PUSH_OPEN_URL)
             if (link == null) {
-                link = intent.getStringExtra(PUSH_COMMAND)
+                link = intent.getStringExtra(STR_PUSH_COMMAND)
             }
             if (link == null) {
-                link = intent.getStringExtra(PUSH_DEEP_LINK)
+                link = intent.getStringExtra(STR_PUSH_DEEP_LINK)
             }
 
             return link

--- a/app/src/main/java/org/mozilla/rocket/debugging/DebugActivity.kt
+++ b/app/src/main/java/org/mozilla/rocket/debugging/DebugActivity.kt
@@ -13,16 +13,11 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.Observer
-import kotlinx.android.synthetic.main.activity_debug.debug_firebase_id
-import kotlinx.android.synthetic.main.activity_debug.debug_firebase_register_token
-import kotlinx.android.synthetic.main.activity_debug.debug_locale_layout
-import kotlinx.android.synthetic.main.activity_debug.debug_locale_text
-import kotlinx.android.synthetic.main.activity_debug.debug_mission_reminder
-import kotlinx.android.synthetic.main.activity_debug.toolbar
+import kotlinx.android.synthetic.main.activity_debug.*
 import org.json.JSONArray
 import org.mozilla.focus.R
 import org.mozilla.focus.utils.FirebaseHelper
-import org.mozilla.rocket.content.appContext
+import org.mozilla.focus.utils.Settings
 import org.mozilla.rocket.preference.stringLiveData
 import java.util.concurrent.TimeUnit
 
@@ -39,6 +34,14 @@ class DebugActivity : AppCompatActivity() {
         preference = getSharedPreferences(PREF_NAME_DEBUG, Context.MODE_PRIVATE)
         initDebugLocale()
         initDebugMissionReminderNotification()
+        initDebugServerPush()
+    }
+
+    private fun initDebugServerPush() {
+        switch_disable_server_push.isChecked = Settings.getInstance(this).isServerPushDebugging
+        switch_disable_server_push.setOnCheckedChangeListener { _, isChecked ->
+            Settings.getInstance(this).isServerPushDebugging = isChecked
+        }
     }
 
     override fun onSupportNavigateUp(): Boolean {

--- a/app/src/main/java/org/mozilla/rocket/periodic/FirstLaunchWorker.kt
+++ b/app/src/main/java/org/mozilla/rocket/periodic/FirstLaunchWorker.kt
@@ -11,8 +11,10 @@ import org.json.JSONException
 import org.json.JSONObject
 import org.mozilla.focus.BuildConfig
 import org.mozilla.focus.FocusApplication
-import org.mozilla.focus.notification.FirebaseMessagingServiceWrapper
 import org.mozilla.focus.notification.NotificationUtil
+import org.mozilla.focus.notification.RocketMessagingService.Companion.STR_PUSH_COMMAND
+import org.mozilla.focus.notification.RocketMessagingService.Companion.STR_PUSH_DEEP_LINK
+import org.mozilla.focus.notification.RocketMessagingService.Companion.STR_PUSH_OPEN_URL
 import org.mozilla.focus.telemetry.TelemetryWrapper
 import org.mozilla.focus.utils.AppConfigWrapper
 import org.mozilla.focus.utils.IntentUtils
@@ -102,9 +104,9 @@ fun String.jsonStringToFirstrunNotification(): FirstrunNotification? {
             jsonObject.getString("messageId"),
             jsonObject.optString("title", null),
             jsonObject.getString("message"),
-            jsonObject.optString(FirebaseMessagingServiceWrapper.PUSH_OPEN_URL, null),
-            jsonObject.optString(FirebaseMessagingServiceWrapper.PUSH_COMMAND, null),
-            jsonObject.optString(FirebaseMessagingServiceWrapper.PUSH_DEEP_LINK, null)
+            jsonObject.optString(STR_PUSH_OPEN_URL, null),
+            jsonObject.optString(STR_PUSH_COMMAND, null),
+            jsonObject.optString(STR_PUSH_DEEP_LINK, null)
         )
     } catch (e: JSONException) {
         e.printStackTrace()

--- a/app/src/main/res/layout/activity_debug.xml
+++ b/app/src/main/res/layout/activity_debug.xml
@@ -86,4 +86,20 @@
 
     </LinearLayout>
 
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="16dp">
+
+        <Switch
+            android:id="@+id/switch_disable_server_push"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textSize="16sp"
+            android:textColor="@android:color/black"
+            android:text="Server Push Debugging"/>
+
+    </LinearLayout>
+
 </LinearLayout>

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -95,4 +95,7 @@
     <!-- Hashed FCM Token   -->
     <string name="pref_int_fcm_token" translatable="false"><xliff:g id="preference_key">pref_int_fcm_token</xliff:g></string>
 
+    <!-- Server Push Debugging   -->
+    <string name="pre_bool_is_server_push_enabled" translatable="false"><xliff:g id="preference_key">pre_bool_is_server_push_enabled</xliff:g></string>
+
 </resources>

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -91,4 +91,8 @@
     <!-- Private Mode - count of the times user leave private mode -->
     <string name="pref_key_pb_int_leave_count" translatable="false"><xliff:g id="preference_key">pref_key_pb_leave_count</xliff:g>></string>
     <string name="pref_key_pb_boolean_shortcut_created" translatable="false"><xliff:g id="preference_key">pref_key_pb_shortcut_created</xliff:g>></string>
+
+    <!-- Hashed FCM Token   -->
+    <string name="pref_int_fcm_token" translatable="false"><xliff:g id="preference_key">pref_int_fcm_token</xliff:g></string>
+
 </resources>

--- a/app/src/test/java/org/mozilla/rocket/component/LaunchIntentDispatcherTest.kt
+++ b/app/src/test/java/org/mozilla/rocket/component/LaunchIntentDispatcherTest.kt
@@ -4,8 +4,8 @@ import android.app.Application
 import android.content.Intent
 import android.content.Intent.ACTION_MAIN
 import androidx.test.core.app.ApplicationProvider
-import org.mozilla.focus.notification.FirebaseMessagingServiceWrapper.Companion.PUSH_COMMAND
-import org.mozilla.focus.notification.FirebaseMessagingServiceWrapper.Companion.PUSH_OPEN_URL
+import org.mozilla.focus.notification.RocketMessagingService.Companion.STR_PUSH_COMMAND
+import org.mozilla.focus.notification.RocketMessagingService.Companion.STR_PUSH_OPEN_URL
 
 // @RunWith(RobolectricTestRunner::class)
 class LaunchIntentDispatcherTest {
@@ -13,11 +13,11 @@ class LaunchIntentDispatcherTest {
 //    @Test
     fun dispatch() {
         val command = Intent()
-        command.putExtra(PUSH_COMMAND, LaunchIntentDispatcher.Command.SET_DEFAULT.value)
+        command.putExtra(STR_PUSH_COMMAND, LaunchIntentDispatcher.Command.SET_DEFAULT.value)
         test(command, LaunchIntentDispatcher.Action.HANDLED)
 
         val view = Intent()
-        view.putExtra(PUSH_OPEN_URL, "https://mozilla.com")
+        view.putExtra(STR_PUSH_OPEN_URL, "https://mozilla.com")
         test(view, LaunchIntentDispatcher.Action.NORMAL)
 
         val launch = Intent()

--- a/components/service/telemetry-compiler/src/main/java/org/mozilla/telemetry/compiler/TelemetryAnnotationProcessor.java
+++ b/components/service/telemetry-compiler/src/main/java/org/mozilla/telemetry/compiler/TelemetryAnnotationProcessor.java
@@ -41,7 +41,7 @@ import javax.tools.StandardLocation;
 @AutoService(Processor.class)
 public class TelemetryAnnotationProcessor extends AbstractProcessor {
 
-    private static final String fileReadme = "/docs/events.md";
+    static final String fileReadme = "/docs/events.md";
     private static final String fileAmplitudeMapping = "/docs/view.sql";
     private static final String FILE_SOURCE_SQL = "view-replace.sql";
     private static final String FILE_SOURCE_SQL_PLACE_HOLDER = "---REPLACE---ME---";

--- a/components/service/telemetry-compiler/src/test/java/org/mozilla/telemetry/compiler/TelemetryAnnotationProcessorTest.java
+++ b/components/service/telemetry-compiler/src/test/java/org/mozilla/telemetry/compiler/TelemetryAnnotationProcessorTest.java
@@ -38,7 +38,7 @@ public class TelemetryAnnotationProcessorTest {
                                 "}"
                         )).generatedFiles();
         assert (telemetryWrapper.size() == 1);
-        assert (new File(TelemetryAnnotationProcessor.FILE_README).exists());
+        assert (new File(TelemetryAnnotationProcessor.fileReadme).exists());
     }
 
     @Test

--- a/firebase/src/main/java/org/mozilla/focus/notification/FirebaseMessagingServiceWrapper.kt
+++ b/firebase/src/main/java/org/mozilla/focus/notification/FirebaseMessagingServiceWrapper.kt
@@ -4,7 +4,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.focus.notification
 
-import android.content.Intent
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 
@@ -16,25 +15,18 @@ import com.google.firebase.messaging.RemoteMessage
  * If actual impl is provided, it'll handle the push and call onRemoteMessage().
  */
 abstract class FirebaseMessagingServiceWrapper : FirebaseMessagingService() {
-    abstract fun onNotificationMessage(intent: Intent, title: String?, body: String?)
+    abstract fun onNotificationMessage(data: Map<String, String>, title: String?, body: String?, imageUrl: String?)
 
     override fun onMessageReceived(remoteMessage: RemoteMessage) {
         // This happens when the app is running in foreground, and the user clicks on the push
         // notification with payload "PUSH_OPEN_URL"
         if (remoteMessage.notification != null) {
-            val intent = Intent()
-            // check if message contains data payload
-            intent.putExtra(MESSAGE_ID, remoteMessage.data[MESSAGE_ID])
-            intent.putExtra(PUSH_OPEN_URL, remoteMessage.data[PUSH_OPEN_URL])
-            intent.putExtra(PUSH_COMMAND, remoteMessage.data[PUSH_COMMAND])
-            intent.putExtra(PUSH_DEEP_LINK, remoteMessage.data[PUSH_DEEP_LINK])
-            remoteMessage.notification?.imageUrl?.let {
-                intent.putExtra(PUSH_IMAGE_URL, it.toString())
-            }
+
             val title = remoteMessage.notification?.title
             val body = remoteMessage.notification?.body
+            val imageUrl = remoteMessage.notification?.imageUrl?.toString()
             // We have a remote message from gcm, let the child decides what to do with it.
-            onNotificationMessage(intent, title, body)
+            onNotificationMessage(remoteMessage.data, title, body, imageUrl)
         }
     }
 

--- a/firebase/src/main/java/org/mozilla/focus/notification/FirebaseMessagingServiceWrapper.kt
+++ b/firebase/src/main/java/org/mozilla/focus/notification/FirebaseMessagingServiceWrapper.kt
@@ -16,7 +16,7 @@ import com.google.firebase.messaging.RemoteMessage
  * If actual impl is provided, it'll handle the push and call onRemoteMessage().
  */
 abstract class FirebaseMessagingServiceWrapper : FirebaseMessagingService() {
-    abstract fun onRemoteMessage(intent: Intent, title: String?, body: String?)
+    abstract fun onNotificationMessage(intent: Intent, title: String?, body: String?)
 
     override fun onMessageReceived(remoteMessage: RemoteMessage) {
         // This happens when the app is running in foreground, and the user clicks on the push
@@ -34,7 +34,7 @@ abstract class FirebaseMessagingServiceWrapper : FirebaseMessagingService() {
             val title = remoteMessage.notification?.title
             val body = remoteMessage.notification?.body
             // We have a remote message from gcm, let the child decides what to do with it.
-            onRemoteMessage(intent, title, body)
+            onNotificationMessage(intent, title, body)
         }
     }
 

--- a/firebase/src/main/java/org/mozilla/focus/notification/FirebaseMessagingServiceWrapper.kt
+++ b/firebase/src/main/java/org/mozilla/focus/notification/FirebaseMessagingServiceWrapper.kt
@@ -34,5 +34,4 @@ abstract class FirebaseMessagingServiceWrapper : FirebaseMessagingService() {
             onDataMessage(remoteMessage.data)
         }
     }
-
 }

--- a/firebase/src/main/java/org/mozilla/focus/notification/FirebaseMessagingServiceWrapper.kt
+++ b/firebase/src/main/java/org/mozilla/focus/notification/FirebaseMessagingServiceWrapper.kt
@@ -17,6 +17,8 @@ import com.google.firebase.messaging.RemoteMessage
 abstract class FirebaseMessagingServiceWrapper : FirebaseMessagingService() {
     abstract fun onNotificationMessage(data: Map<String, String>, title: String?, body: String?, imageUrl: String?)
 
+    abstract fun onDataMessage(data: MutableMap<String, String>)
+
     override fun onMessageReceived(remoteMessage: RemoteMessage) {
         // This happens when the app is running in foreground, and the user clicks on the push
         // notification with payload "PUSH_OPEN_URL"
@@ -27,14 +29,10 @@ abstract class FirebaseMessagingServiceWrapper : FirebaseMessagingService() {
             val imageUrl = remoteMessage.notification?.imageUrl?.toString()
             // We have a remote message from gcm, let the child decides what to do with it.
             onNotificationMessage(remoteMessage.data, title, body, imageUrl)
+        } else if (remoteMessage.data.isNotEmpty()) {
+
+            onDataMessage(remoteMessage.data)
         }
     }
 
-    companion object {
-        const val MESSAGE_ID = "message_id"
-        const val PUSH_OPEN_URL = "push_open_url"
-        const val PUSH_COMMAND = "push_command"
-        const val PUSH_DEEP_LINK = "push_deep_link"
-        const val PUSH_IMAGE_URL = "push_image_url"
-    }
 }


### PR DESCRIPTION
I first thought making push payload as a POJO for server and client could be a good idea.
But FCM SDK already parses the data payload into HashMap.
And we need Bundle as input data for WorkManager to schedule when to display the notification.
So I'll just reuse current architecture.

For extracting the methods.
Normally it's a bad idea to mix the Context of a Service and the Application Context.
But here we only use it for 
1. getting WorkManager
2. getting String Resources, 
3. Building the Notification

So it should be fine