### PR TITLE
Add 'travel_search_engine_2' string resouce back to avoid build break

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -958,6 +958,8 @@
     <string name="travel_find_destination_placeholder_2">Enter a destination</string>
     <!--this is a title indicates that users will see search results from google after tapping on the following option. the %1$s here is google. -->
     <string name="travel_search_engine_1">See results in %1$s</string>
+    <!--this is a title indicates that users will see search results summerized by smart travel search after tapping on the following options. -->
+    <string name="travel_search_engine_2">See results in smart travel search</string>
     <!--this is a title indicates that users will see search results summerized by Travel Discovery after tapping on the following options. the %1$s here is Firefox Lite.-->
     <string name="travel_search_engine_fxlite">See results in %1$s Travel Discovery</string>   
     <!--this is a title indicates that users will see search results summerized by Travel Discovery after tapping on the following options. the first %1$s is Firefox Lite, and the %2$s is Travel Discovery.-->


### PR DESCRIPTION
We removed the `travel_search_engine_2` from string resources, however, the string is not removed from Pontoon that required a PR to l10n repository. Also, there is a cron job everyday to import latest l10n string from Pontoon, that causes the lint violation - having string resources in specific language but not existed in "main". We'll discuss the string removal process with release manager, and currently add the string back to avoid build break.  