### PR TITLE
Downgrade to appcompat 1.1.0-rc1 to avoid webview crash on Android 5 devices

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -298,6 +298,15 @@ dependencies {
     implementation "com.google.android.play:core:${Versions.play}"
 }
 
+// There is a issue with Appcompat 1.1.0 which has the WebView crash on Android 5 devices.
+// https://issuetracker.google.com/issues/141132133
+// We downgraded the libraries to 1.1.0-rc1 and need to check and upgrade to 1.2.0 in the future.
+configurations.all {
+    resolutionStrategy {
+        force "androidx.appcompat:appcompat:${Versions.appcompat}"
+    }
+}
+
 // -------------------------------------------------------------------------------------------------
 // Generate blocklists
 // -------------------------------------------------------------------------------------------------

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -8,7 +8,7 @@ object Versions {
     const val android_gradle_plugin = "3.6.1"
     const val gms_oss_licenses_plugin = "0.10.2"
     const val support = "1.0.0"
-    const val appcompat = "1.1.0"
+    const val appcompat = "1.1.0-rc01"
     const val material = "1.0.0"
     const val cardview = "1.0.0"
     const val recyclerview = "1.1.0"


### PR DESCRIPTION
https://issuetracker.google.com/issues/141132133