### PR TITLE
Pref off Token Upload In Production

### DIFF
--- a/app/src/main/java/org/mozilla/focus/utils/FirebaseHelper.kt
+++ b/app/src/main/java/org/mozilla/focus/utils/FirebaseHelper.kt
@@ -269,7 +269,10 @@ object FirebaseHelper {
     @JvmStatic
     fun initUserState(activity: Activity) {
         firebaseContract.initUserState(activity)
-        RocketMessagingService.checkFcmTokenUploaded(activity.applicationContext)
+        // we only upload Push Token in below channel
+        if (AppConstants.isNightlyBuild() || AppConstants.isDevBuild() || AppConstants.isFirebaseBuild()) {
+            RocketMessagingService.checkFcmTokenUploaded(activity.applicationContext)
+        }
     }
 
     @JvmStatic


### PR DESCRIPTION
Only upload fcm token when it's dev/firebase/nightly build.

the release build type is used by nightly(preview) and production(focus) product flavor.
