### PR TITLE
limit string length for firebase's user properties

### DIFF
--- a/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
+++ b/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
@@ -3947,7 +3947,7 @@ object TelemetryWrapper {
                 if (LocalAbTesting.assignedBuckets.isEmpty()) {
                     "null"
                 } else {
-                    LocalAbTesting.assignedBuckets.joinToString(separator = ",")
+                    LocalAbTesting.assignedBuckets.first()
                 }
             } else {
                 FirebaseHelper.getFirebase().getRcString(FirebaseHelper.STR_EXPERIMENT_NAME)

--- a/app/src/main/java/org/mozilla/rocket/abtesting/LocalAbTesting.kt
+++ b/app/src/main/java/org/mozilla/rocket/abtesting/LocalAbTesting.kt
@@ -9,6 +9,7 @@ import org.mozilla.rocket.util.AssetsUtils
 import org.mozilla.rocket.util.getJsonArray
 
 object LocalAbTesting {
+    private const val FIREBASE_USER_PROPERTY_VALUE_MAX_LENGTH = 36
     private val NUMBER_RANGE = (1..20)
 
     private lateinit var appContext: Context
@@ -31,6 +32,11 @@ object LocalAbTesting {
         activeExperiments.flatMap { it.buckets }
                 .filter { it.bucket_range_start <= userGroup && userGroup <= it.bucket_range_end }
                 .map { it.experiment_name }
+                .also { experimentName ->
+                    if (experimentName.any { it.length > FIREBASE_USER_PROPERTY_VALUE_MAX_LENGTH }) {
+                        error("UserProperty values can only be up to 36 characters long.")
+                    }
+                }
     }
 
     fun init(context: Context) {


### PR DESCRIPTION
according to the documentation from firebase:
UserProperty values can be up to 36 characters long.
https://firebase.google.com/docs/reference/android/com/google/firebase/analytics/FirebaseAnalytics.UserProperty


