### PR TITLE
catch and log exception when parsing news response

### DIFF
--- a/app/src/main/java/org/mozilla/rocket/content/news/data/newspoint/NewsPointNewsRemoteDataSource.kt
+++ b/app/src/main/java/org/mozilla/rocket/content/news/data/newspoint/NewsPointNewsRemoteDataSource.kt
@@ -23,30 +23,30 @@ class NewsPointNewsRemoteDataSource(
         val pageSize = params.requestedLoadSize
         val pages = 1
 
-        val result = fetchNewsItems(category, language, pageSize, pages)
-        if (result is Result.Success) {
-            callback.onResult(result.data, null, PageKey.PageNumberKey(2))
-        } // TODO: error handling
+        when (val result = fetchNewsItems(category, language, pageSize, pages)) {
+            is Result.Success -> callback.onResult(result.data, null, PageKey.PageNumberKey(2))
+            is Result.Error -> result.exception.printStackTrace()
+        }
     }
 
     override fun loadBefore(params: LoadParams<PageKey>, callback: LoadCallback<PageKey, NewsItem>) {
         val pageSize = params.requestedLoadSize
         val pages = (params.key as PageKey.PageNumberKey).number
 
-        val result = fetchNewsItems(category, language, pageSize, pages)
-        if (result is Result.Success) {
-            callback.onResult(result.data, PageKey.PageNumberKey(pages - 1))
-        } // TODO: error handling
+        when (val result = fetchNewsItems(category, language, pageSize, pages)) {
+            is Result.Success -> callback.onResult(result.data, PageKey.PageNumberKey(pages - 1))
+            is Result.Error -> result.exception.printStackTrace()
+        }
     }
 
     override fun loadAfter(params: LoadParams<PageKey>, callback: LoadCallback<PageKey, NewsItem>) {
         val pageSize = params.requestedLoadSize
         val pages = (params.key as PageKey.PageNumberKey).number
 
-        val result = fetchNewsItems(category, language, pageSize, pages)
-        if (result is Result.Success) {
-            callback.onResult(result.data, PageKey.PageNumberKey(pages + 1))
-        } // TODO: error handling
+        when (val result = fetchNewsItems(category, language, pageSize, pages)) {
+            is Result.Success -> callback.onResult(result.data, PageKey.PageNumberKey(pages + 1))
+            is Result.Error -> result.exception.printStackTrace()
+        }
     }
 
     private fun fetchNewsItems(category: String, language: String, pages: Int, pageSize: Int): Result<List<NewsItem>> {
@@ -56,7 +56,11 @@ class NewsPointNewsRemoteDataSource(
                 method = Request.Method.GET
             ),
             onSuccess = {
-                Result.Success(fromJson(it.body.string()))
+                try {
+                    Result.Success(fromJson(it.body.string()))
+                } catch (e: Exception) {
+                    Result.Error(e)
+                }
             },
             onError = {
                 Result.Error(it)

--- a/app/src/main/java/org/mozilla/rocket/content/news/data/rss/RssNewsRemoteDataSource.kt
+++ b/app/src/main/java/org/mozilla/rocket/content/news/data/rss/RssNewsRemoteDataSource.kt
@@ -22,28 +22,28 @@ class RssNewsRemoteDataSource(
     override fun loadInitial(params: LoadInitialParams<PageKey>, callback: LoadInitialCallback<PageKey, NewsItem>) {
         val pages = 1
 
-        val result = fetchNewsItems(category, pages)
-        if (result is Result.Success) {
-            callback.onResult(result.data, null, PageKey.PageNumberKey(2))
-        } // TODO: error handling
+        when (val result = fetchNewsItems(category, pages)) {
+            is Result.Success -> callback.onResult(result.data, null, PageKey.PageNumberKey(2))
+            is Result.Error -> result.exception.printStackTrace()
+        }
     }
 
     override fun loadBefore(params: LoadParams<PageKey>, callback: LoadCallback<PageKey, NewsItem>) {
         val pages = (params.key as PageKey.PageNumberKey).number
 
-        val result = fetchNewsItems(category, pages)
-        if (result is Result.Success) {
-            callback.onResult(result.data, PageKey.PageNumberKey(pages - 1))
-        } // TODO: error handling
+        when (val result = fetchNewsItems(category, pages)) {
+            is Result.Success -> callback.onResult(result.data, PageKey.PageNumberKey(pages - 1))
+            is Result.Error -> result.exception.printStackTrace()
+        }
     }
 
     override fun loadAfter(params: LoadParams<PageKey>, callback: LoadCallback<PageKey, NewsItem>) {
         val pages = (params.key as PageKey.PageNumberKey).number
 
-        val result = fetchNewsItems(category, pages)
-        if (result is Result.Success) {
-            callback.onResult(result.data, PageKey.PageNumberKey(pages + 1))
-        } // TODO: error handling
+        when (val result = fetchNewsItems(category, pages)) {
+            is Result.Success -> callback.onResult(result.data, PageKey.PageNumberKey(pages + 1))
+            is Result.Error -> result.exception.printStackTrace()
+        }
     }
 
     private fun fetchNewsItems(category: String, pages: Int): Result<List<NewsItem>> {
@@ -53,7 +53,11 @@ class RssNewsRemoteDataSource(
             sendHttpRequest(
                 request = Request(url = getApiEndpoint(category), method = Request.Method.GET),
                 onSuccess = {
-                    Result.Success(fromJson(it.body.string()))
+                    try {
+                        Result.Success(fromJson(it.body.string()))
+                    } catch (e: Exception) {
+                        Result.Error(e)
+                    }
                 },
                 onError = {
                     Result.Error(it)


### PR DESCRIPTION
to catch the exceptions when parsing news API response like before
to ignore unexpected error response: https://console.firebase.google.com/u/0/project/zerda-dcf76/crashlytics/app/android:org.mozilla.rocket/issues/22369123009cac28498ae83b2db367d4?time=last-seven-days&sessionId=5EA6A242021300014C10D2C27B526BC4_DNE_0_v2