### PR TITLE
Enable Firebase Monitoring in Nightly

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,6 +8,7 @@ apply from: '../buildSrc/pmd.gradle'
 apply from: '../buildSrc/checkstyle.gradle'
 apply from: '../buildSrc/findbugs.gradle'
 apply from: 'buildscripts/l10n.gradle'
+apply plugin: 'com.google.firebase.firebase-perf'
 
 android {
     compileSdkVersion Versions.compile_sdk

--- a/app/src/main/java/org/mozilla/focus/navigation/ScreenNavigator.kt
+++ b/app/src/main/java/org/mozilla/focus/navigation/ScreenNavigator.kt
@@ -14,6 +14,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Transformations
 import org.mozilla.focus.BuildConfig
+import org.mozilla.focus.utils.FirebaseHelper
 import org.mozilla.focus.widget.BackKeyHandleable
 import java.util.Arrays
 
@@ -102,6 +103,9 @@ open class ScreenNavigator(private val activity: HostActivity?) : DefaultLifecyc
      * fragment. Use this when you want to start a new tab.
      */
     open fun addHomeScreen(animate: Boolean) {
+        val trace = FirebaseHelper.newTrace("addHomeScreen")
+        trace.start()
+
         logMethod()
         val found = transactionHelper?.popScreensUntil(HOME_FRAGMENT_TAG,
             TransactionHelper.EntryData.TYPE_ATTACHED,
@@ -113,6 +117,7 @@ open class ScreenNavigator(private val activity: HostActivity?) : DefaultLifecyc
                 false)
         }
         transactionHelper?.executePendingTransaction()
+        trace.stop()
     }
 
     /**

--- a/app/src/main/java/org/mozilla/focus/utils/FirebaseHelper.kt
+++ b/app/src/main/java/org/mozilla/focus/utils/FirebaseHelper.kt
@@ -305,4 +305,8 @@ object FirebaseHelper {
     fun refreshRemoteConfig(callback: (Boolean, e: Exception?) -> Unit) {
         firebaseContract.refreshRemoteConfig(callback)
     }
+
+    fun newTrace(key: String): FirebaseContract.TraceHelper {
+        return firebaseContract.newTrace(key)
+    }
 }

--- a/app/src/main/java/org/mozilla/focus/utils/FirebaseHelper.kt
+++ b/app/src/main/java/org/mozilla/focus/utils/FirebaseHelper.kt
@@ -306,7 +306,7 @@ object FirebaseHelper {
         firebaseContract.refreshRemoteConfig(callback)
     }
 
-    fun newTrace(key: String): FirebaseContract.TraceHelper {
+    fun newTrace(key: String): FirebaseContract.FirebaseTrace {
         return firebaseContract.newTrace(key)
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,8 @@ buildscript {
         classpath "com.google.android.gms:oss-licenses-plugin:${Versions.gms_oss_licenses_plugin}"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.kotlin}"
         classpath "androidx.navigation:navigation-safe-args-gradle-plugin:${Versions.navigation}"
+        classpath 'com.google.firebase:perf-plugin:1.3.1'  // Performance Monitoring plugin
+
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -50,7 +50,7 @@ object Versions {
     const val firebase_config = "19.0.3"
     const val firebase_auth = "19.2.0"
     const val firebase_iam = "19.0.3"
-    const val fcm = "20.0.1"
+    const val fcm = "20.2.0"
     const val crashlytics = "2.10.1"
     const val google_services_plugin = "3.1.1"
     const val fabric_plugin = "1.25.1"

--- a/firebase/build.gradle
+++ b/firebase/build.gradle
@@ -64,6 +64,14 @@ android {
         }
 
     }
+
+    variantFilter { variant ->
+        def flavors = variant.flavors*.name
+        // We only need a nightly release for now
+        if (flavors.contains("preview") && variant.buildType.name != "release") {
+            setIgnore(true)
+        }
+    }
 }
 
 dependencies {

--- a/firebase/build.gradle
+++ b/firebase/build.gradle
@@ -47,6 +47,23 @@ android {
             resValue "string", "com.crashlytics.android.build_id", UUID.randomUUID().toString()
         }
     }
+    flavorDimensions "product", "engine"
+
+    productFlavors {
+        focus {
+            dimension "product"
+        }
+
+        preview {
+            dimension "product"
+        }
+
+        // We can build with two engines: webkit or gecko
+        webkit {
+            dimension "engine"
+        }
+
+    }
 }
 
 dependencies {
@@ -58,7 +75,8 @@ dependencies {
     api "com.google.firebase:firebase-messaging:${Versions.fcm}"
     implementation "com.crashlytics.sdk.android:crashlytics:${Versions.crashlytics}"
     implementation "com.google.firebase:firebase-auth:${Versions.firebase_auth}"
-    implementation 'com.google.firebase:firebase-perf:19.0.7'
+    previewImplementation 'com.google.firebase:firebase-perf:19.0.7'
+    debugImplementation 'com.google.firebase:firebase-perf:19.0.7'
     implementation ("com.google.firebase:firebase-inappmessaging-display:${Versions.firebase_iam}") {
         // TODO: need to check if it can be moved to firebase module after this or worker manager libraries upgraded
         // has conflicts with existing library

--- a/firebase/build.gradle
+++ b/firebase/build.gradle
@@ -58,6 +58,7 @@ dependencies {
     api "com.google.firebase:firebase-messaging:${Versions.fcm}"
     implementation "com.crashlytics.sdk.android:crashlytics:${Versions.crashlytics}"
     implementation "com.google.firebase:firebase-auth:${Versions.firebase_auth}"
+    implementation 'com.google.firebase:firebase-perf:19.0.7'
     implementation ("com.google.firebase:firebase-inappmessaging-display:${Versions.firebase_iam}") {
         // TODO: need to check if it can be moved to firebase module after this or worker manager libraries upgraded
         // has conflicts with existing library

--- a/firebase/src/focusWebkitDebug/java/org/mozilla/focus/utils/FirebaseTraceImp.kt
+++ b/firebase/src/focusWebkitDebug/java/org/mozilla/focus/utils/FirebaseTraceImp.kt
@@ -1,0 +1,25 @@
+/* -*- Mode: Java; c-basic-offset: 4; tab-width: 4; indent-tabs-mode: nil; -*-
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus.utils
+
+import com.google.firebase.perf.FirebasePerformance
+import com.google.firebase.perf.metrics.Trace
+
+/**
+ * It's a wrapper to communicate with Firebase Monitoring
+ */
+class FirebaseTraceImp(key: String) : FirebaseContract.FirebaseTrace {
+
+    private val trace: Trace = FirebasePerformance.getInstance().newTrace(key)
+
+    override fun start() {
+        trace.start()
+    }
+
+    override fun stop() {
+        trace.stop()
+    }
+}

--- a/firebase/src/focusWebkitRelease/java/org/mozilla/focus/utils/FirebaseTraceImp.kt
+++ b/firebase/src/focusWebkitRelease/java/org/mozilla/focus/utils/FirebaseTraceImp.kt
@@ -1,0 +1,18 @@
+/* -*- Mode: Java; c-basic-offset: 4; tab-width: 4; indent-tabs-mode: nil; -*-
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus.utils
+
+/**
+ * It's a wrapper to communicate with Firebase Monitoring
+ */
+class FirebaseTraceImp(key: String) : FirebaseContract.FirebaseTrace {
+
+    override fun start() {
+    }
+
+    override fun stop() {
+    }
+}

--- a/firebase/src/main/java/org/mozilla/focus/utils/FirebaseContract.kt
+++ b/firebase/src/main/java/org/mozilla/focus/utils/FirebaseContract.kt
@@ -78,9 +78,9 @@ abstract class FirebaseContract(var remoteConfigDefault: HashMap<String, Any> = 
 
     abstract fun addIamClickListener(clickListener: (InAppMessage, InAppMessage.Action) -> Unit)
 
-    abstract fun newTrace(key: String): TraceHelper
+    abstract fun newTrace(key: String): FirebaseTrace
 
-    interface TraceHelper {
+    interface FirebaseTrace {
         fun start()
         fun stop()
     }

--- a/firebase/src/main/java/org/mozilla/focus/utils/FirebaseContract.kt
+++ b/firebase/src/main/java/org/mozilla/focus/utils/FirebaseContract.kt
@@ -77,4 +77,11 @@ abstract class FirebaseContract(var remoteConfigDefault: HashMap<String, Any> = 
     abstract fun addIamImpressionListener(impressionListener: (InAppMessage) -> Unit)
 
     abstract fun addIamClickListener(clickListener: (InAppMessage, InAppMessage.Action) -> Unit)
+
+    abstract fun newTrace(key: String): TraceHelper
+
+    interface TraceHelper {
+        fun start()
+        fun stop()
+    }
 }

--- a/firebase/src/main/java/org/mozilla/focus/utils/FirebaseImp.kt
+++ b/firebase/src/main/java/org/mozilla/focus/utils/FirebaseImp.kt
@@ -17,6 +17,8 @@ import com.google.firebase.analytics.FirebaseAnalytics
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.iid.FirebaseInstanceId
 import com.google.firebase.inappmessaging.FirebaseInAppMessaging
+import com.google.firebase.perf.FirebasePerformance
+import com.google.firebase.perf.metrics.Trace
 import com.google.firebase.remoteconfig.FirebaseRemoteConfig
 import com.google.firebase.remoteconfig.FirebaseRemoteConfigSettings
 import io.fabric.sdk.android.Fabric
@@ -242,5 +244,20 @@ open class FirebaseImp(fromResourceString: HashMap<String, Any>) : FirebaseContr
         FirebaseInAppMessaging.getInstance().addClickListener { inAppMessage, action ->
             clickListener(InAppMessage(inAppMessage), InAppMessage.Action(action))
         }
+    }
+
+    override fun newTrace(key: String): TraceHelper {
+        return TraceWrapper(FirebasePerformance.getInstance().newTrace(key))
+    }
+}
+
+class TraceWrapper(private val trace: Trace) : FirebaseContract.TraceHelper {
+
+    override fun start() {
+        trace.start()
+    }
+
+    override fun stop() {
+        trace.stop()
     }
 }

--- a/firebase/src/main/java/org/mozilla/focus/utils/FirebaseImp.kt
+++ b/firebase/src/main/java/org/mozilla/focus/utils/FirebaseImp.kt
@@ -17,8 +17,6 @@ import com.google.firebase.analytics.FirebaseAnalytics
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.iid.FirebaseInstanceId
 import com.google.firebase.inappmessaging.FirebaseInAppMessaging
-import com.google.firebase.perf.FirebasePerformance
-import com.google.firebase.perf.metrics.Trace
 import com.google.firebase.remoteconfig.FirebaseRemoteConfig
 import com.google.firebase.remoteconfig.FirebaseRemoteConfigSettings
 import io.fabric.sdk.android.Fabric
@@ -246,18 +244,7 @@ open class FirebaseImp(fromResourceString: HashMap<String, Any>) : FirebaseContr
         }
     }
 
-    override fun newTrace(key: String): TraceHelper {
-        return TraceWrapper(FirebasePerformance.getInstance().newTrace(key))
-    }
-}
-
-class TraceWrapper(private val trace: Trace) : FirebaseContract.TraceHelper {
-
-    override fun start() {
-        trace.start()
-    }
-
-    override fun stop() {
-        trace.stop()
+    override fun newTrace(key: String): FirebaseTrace {
+        return FirebaseTraceImp(key)
     }
 }

--- a/firebase/src/main/java/org/mozilla/focus/utils/FirebaseNoOpImp.kt
+++ b/firebase/src/main/java/org/mozilla/focus/utils/FirebaseNoOpImp.kt
@@ -105,8 +105,8 @@ open class FirebaseNoOpImp(remoteConfigDefault: HashMap<String, Any> = HashMap()
     override fun addIamClickListener(clickListener: (InAppMessage, InAppMessage.Action) -> Unit) {
     }
 
-    override fun newTrace(key: String): TraceHelper {
-        return object : TraceHelper {
+    override fun newTrace(key: String): FirebaseTrace {
+        return object : FirebaseTrace {
             override fun start() {
             }
 

--- a/firebase/src/main/java/org/mozilla/focus/utils/FirebaseNoOpImp.kt
+++ b/firebase/src/main/java/org/mozilla/focus/utils/FirebaseNoOpImp.kt
@@ -104,4 +104,14 @@ open class FirebaseNoOpImp(remoteConfigDefault: HashMap<String, Any> = HashMap()
 
     override fun addIamClickListener(clickListener: (InAppMessage, InAppMessage.Action) -> Unit) {
     }
+
+    override fun newTrace(key: String): TraceHelper {
+        return object : TraceHelper {
+            override fun start() {
+            }
+
+            override fun stop() {
+            }
+        }
+    }
 }

--- a/firebase/src/previewWebkitRelease/java/org/mozilla/focus/utils/FirebaseTraceImp.kt
+++ b/firebase/src/previewWebkitRelease/java/org/mozilla/focus/utils/FirebaseTraceImp.kt
@@ -1,0 +1,25 @@
+/* -*- Mode: Java; c-basic-offset: 4; tab-width: 4; indent-tabs-mode: nil; -*-
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus.utils
+
+import com.google.firebase.perf.FirebasePerformance
+import com.google.firebase.perf.metrics.Trace
+
+/**
+ * It's a wrapper to communicate with Firebase Monitoring
+ */
+class FirebaseTraceImp(key: String) : FirebaseContract.FirebaseTrace {
+
+    private val trace: Trace = FirebasePerformance.getInstance().newTrace(key)
+
+    override fun start() {
+        trace.start()
+    }
+
+    override fun stop() {
+        trace.stop()
+    }
+}


### PR DESCRIPTION
related to #4988
I'll like to merge Firebase performance monitoring in Nightly only and collect some key performance metrics (e.g. cold start)