### PR TITLE
Show the retry snackbar when user launches FxLite without finishing the set-default-browser flow

### DIFF
--- a/app/src/main/java/org/mozilla/focus/notification/NotificationActionBroadcastReceiver.java
+++ b/app/src/main/java/org/mozilla/focus/notification/NotificationActionBroadcastReceiver.java
@@ -20,7 +20,6 @@ import org.mozilla.focus.utils.AppConstants;
 import org.mozilla.focus.utils.IntentUtils;
 import org.mozilla.focus.utils.Settings;
 import org.mozilla.focus.utils.SupportUtils;
-import org.mozilla.rocket.deeplink.DeepLinkConstants;
 
 import static org.mozilla.focus.notification.RocketMessagingService.STR_PUSH_COMMAND;
 import static org.mozilla.focus.notification.RocketMessagingService.STR_PUSH_DEEP_LINK;
@@ -96,9 +95,7 @@ public class NotificationActionBroadcastReceiver extends BroadcastReceiver {
             NotificationManagerCompat.from(context).cancel(NotificationId.LOVE_FIREFOX);
 
         } else if (bundle.getBoolean(IntentUtils.EXTRA_NOTIFICATION_CLICK_DEFAULT_BROWSER)) {
-            nexStep = new Intent();
-            nexStep.setClassName(context, AppConstants.LAUNCHER_ACTIVITY_ALIAS);
-            nexStep.putExtra(STR_PUSH_DEEP_LINK, "rocket://command?command=" + DeepLinkConstants.COMMAND_SET_DEFAULT_BROWSER);
+            nexStep = IntentUtils.createSetDefaultBrowserIntent(context);
 
             TelemetryWrapper.clickDefaultSettingNotification();
 

--- a/app/src/main/java/org/mozilla/focus/utils/IntentUtils.java
+++ b/app/src/main/java/org/mozilla/focus/utils/IntentUtils.java
@@ -24,6 +24,8 @@ import org.mozilla.focus.BuildConfig;
 import org.mozilla.focus.R;
 import org.mozilla.focus.activity.MainActivity;
 import org.mozilla.focus.notification.NotificationActionBroadcastReceiver;
+import org.mozilla.focus.notification.RocketMessagingService;
+import org.mozilla.rocket.deeplink.DeepLinkConstants;
 import org.mozilla.rocket.tabs.TabView;
 
 import java.io.File;
@@ -210,6 +212,13 @@ public class IntentUtils {
         intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
         intent.putExtra(IntentUtils.EXTRA_IS_INTERNAL_REQUEST, true);
         intent.putExtra(IntentUtils.EXTRA_OPEN_NEW_TAB, openInNewTab);
+        return intent;
+    }
+
+    public static Intent createSetDefaultBrowserIntent(Context context) {
+        Intent intent = new Intent();
+        intent.setClassName(context, AppConstants.LAUNCHER_ACTIVITY_ALIAS);
+        intent.putExtra(RocketMessagingService.STR_PUSH_DEEP_LINK, "rocket://command?command=" + DeepLinkConstants.COMMAND_SET_DEFAULT_BROWSER);
         return intent;
     }
 

--- a/app/src/main/java/org/mozilla/rocket/settings/defaultbrowser/data/DefaultBrowserDataSource.kt
+++ b/app/src/main/java/org/mozilla/rocket/settings/defaultbrowser/data/DefaultBrowserDataSource.kt
@@ -3,5 +3,7 @@ package org.mozilla.rocket.settings.defaultbrowser.data
 interface DefaultBrowserDataSource {
     fun isDefaultBrowser(): Boolean
     fun hasDefaultBrowser(): Boolean
+    fun hasSetDefaultBrowserInProgress(): Boolean
+    fun setDefaultBrowserInProgress(isInProgress: Boolean)
     fun getTutorialImagesUrl(): TutorialImagesUrl
 }

--- a/app/src/main/java/org/mozilla/rocket/settings/defaultbrowser/data/DefaultBrowserLocalDataSource.kt
+++ b/app/src/main/java/org/mozilla/rocket/settings/defaultbrowser/data/DefaultBrowserLocalDataSource.kt
@@ -1,15 +1,32 @@
 package org.mozilla.rocket.settings.defaultbrowser.data
 
 import android.content.Context
+import android.preference.PreferenceManager
 import org.mozilla.focus.utils.Browsers
 import org.mozilla.focus.utils.FirebaseHelper
 import org.mozilla.rocket.util.toJsonObject
+import org.mozilla.strictmodeviolator.StrictModeViolation
 
 class DefaultBrowserLocalDataSource(private val applicationContext: Context) : DefaultBrowserDataSource {
+
+    private val preference by lazy {
+        StrictModeViolation.tempGrant({ builder ->
+            builder.permitDiskReads()
+        }, {
+            PreferenceManager.getDefaultSharedPreferences(applicationContext)
+        })
+    }
 
     override fun isDefaultBrowser() = Browsers.isDefaultBrowser(applicationContext)
 
     override fun hasDefaultBrowser() = Browsers.hasDefaultBrowser(applicationContext)
+
+    override fun hasSetDefaultBrowserInProgress() =
+        preference.getBoolean(KEY_SET_DEFAULT_BROWSER_IN_PROGRESS, false)
+
+    override fun setDefaultBrowserInProgress(isInProgress: Boolean) {
+        preference.edit().putBoolean(KEY_SET_DEFAULT_BROWSER_IN_PROGRESS, isInProgress).apply()
+    }
 
     override fun getTutorialImagesUrl(): TutorialImagesUrl {
         val tutorialImagesUrl = FirebaseHelper.getFirebase().getRcString(RC_KEY_STR_SET_DEFAULT_BROWSER_TUTORIAL_IMAGES)
@@ -21,6 +38,7 @@ class DefaultBrowserLocalDataSource(private val applicationContext: Context) : D
     }
 
     companion object {
+        const val KEY_SET_DEFAULT_BROWSER_IN_PROGRESS = "set_default_browser_in_progress"
         const val RC_KEY_STR_SET_DEFAULT_BROWSER_TUTORIAL_IMAGES = "str_set_default_browser_tutorial_images"
     }
 }

--- a/app/src/main/java/org/mozilla/rocket/settings/defaultbrowser/data/DefaultBrowserRepository.kt
+++ b/app/src/main/java/org/mozilla/rocket/settings/defaultbrowser/data/DefaultBrowserRepository.kt
@@ -6,5 +6,9 @@ class DefaultBrowserRepository(private val defaultBrowserDataSource: DefaultBrow
 
     fun hasDefaultBrowser() = defaultBrowserDataSource.hasDefaultBrowser()
 
+    fun hasSetDefaultBrowserInProgress() = defaultBrowserDataSource.hasSetDefaultBrowserInProgress()
+
+    fun setDefaultBrowserInProgress(isInProgress: Boolean) = defaultBrowserDataSource.setDefaultBrowserInProgress(isInProgress)
+
     fun getTutorialImagesUrl(): TutorialImagesUrl = defaultBrowserDataSource.getTutorialImagesUrl()
 }

--- a/app/src/main/java/org/mozilla/rocket/settings/defaultbrowser/ui/DefaultBrowserPreferenceViewModel.kt
+++ b/app/src/main/java/org/mozilla/rocket/settings/defaultbrowser/ui/DefaultBrowserPreferenceViewModel.kt
@@ -28,7 +28,11 @@ class DefaultBrowserPreferenceViewModel(private val defaultBrowserRepository: De
     private var isDefaultBrowser: Boolean = false
     private var hasDefaultBrowser: Boolean = false
 
-    private var tryToSetDefaultBrowser: Boolean = false
+    private var tryToSetDefaultBrowser: Boolean
+        get() = defaultBrowserRepository.hasSetDefaultBrowserInProgress()
+        set(value) {
+            defaultBrowserRepository.setDefaultBrowserInProgress(value)
+        }
 
     fun refreshSettings() {
         isDefaultBrowser = defaultBrowserRepository.isDefaultBrowser()


### PR DESCRIPTION
Related to #4964 
Fix #5070 