### PR TITLE
Do not show set-default-browser retry snackbar when FxLite is already set as default

### DIFF
--- a/app/src/main/java/org/mozilla/focus/activity/MainActivity.kt
+++ b/app/src/main/java/org/mozilla/focus/activity/MainActivity.kt
@@ -366,6 +366,9 @@ class MainActivity : BaseActivity(),
     private fun checkHasSetDefaultBrowserInProgress() {
         if (defaultBrowserRepository.hasSetDefaultBrowserInProgress()) {
             defaultBrowserRepository.setDefaultBrowserInProgress(false)
+            if (defaultBrowserRepository.isDefaultBrowser()) {
+                return
+            }
             val rootView = findViewById<ViewGroup>(android.R.id.content).getChildAt(0) as ViewGroup
             val failMessageText = getString(R.string.message_set_default_incomplet, getString(R.string.app_name))
             Snackbar.make(rootView, failMessageText, TimeUnit.SECONDS.toMillis(8).toInt())


### PR DESCRIPTION
Fix #5082 