### PR TITLE
Fix NPE in settings fragment

### DIFF
--- a/app/src/main/java/org/mozilla/focus/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/settings/SettingsFragment.kt
@@ -50,7 +50,7 @@ class SettingsFragment : PreferenceFragment(), OnSharedPreferenceChangeListener 
         val preferenceNightMode = findPreference(getString(R.string.pref_key_night_mode_brightness))
         preferenceNightMode?.isEnabled = Settings.getInstance(activity).isNightModeEnable
 
-        if (DeepLinkConstants.COMMAND_SET_DEFAULT_BROWSER == arguments.getString(SettingsActivity.EXTRA_ACTION)) {
+        if (DeepLinkConstants.COMMAND_SET_DEFAULT_BROWSER == arguments?.getString(SettingsActivity.EXTRA_ACTION)) {
             triggerSetDefaultBrowserAction()
         }
     }


### PR DESCRIPTION
Fix #5085
```
Fatal Exception: java.lang.NullPointerException
Attempt to invoke virtual method 'java.lang.String android.os.Bundle.getString(java.lang.String)' on a null object reference
org.mozilla.focus.settings.SettingsFragment.onCreate (SettingsFragment.kt:53)
android.app.Fragment.performCreate (Fragment.java:2503)
android.app.FragmentManagerImpl.moveToState (FragmentManager.java:1256)
android.app.FragmentManagerImpl.addAddedFragments (FragmentManager.java:2426)
android.app.FragmentManagerImpl.executeOpsTogether (FragmentManager.java:2205)
android.app.FragmentManagerImpl.removeRedundantOperationsAndExecute (FragmentManager.java:2161)
android.app.FragmentManagerImpl.execPendingActions (FragmentManager.java:2062)
android.app.FragmentManagerImpl$1.run (FragmentManager.java:738)
android.os.Handler.handleCallback (Handler.java:873)
android.os.Handler.dispatchMessage (Handler.java:99)
android.os.Looper.loop (Looper.java:193)
android.app.ActivityThread.main (ActivityThread.java:6746)
java.lang.reflect.Method.invoke (Method.java)
com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:493)
com.android.internal.os.ZygoteInit.main (ZygoteInit.java:858)
```