### PR TITLE
Fix IndexOutOfBoundsException happened while monitoring news items shown event

### DIFF
--- a/app/src/main/java/org/mozilla/rocket/content/news/ui/NewsViewModel.kt
+++ b/app/src/main/java/org/mozilla/rocket/content/news/ui/NewsViewModel.kt
@@ -67,7 +67,7 @@ class NewsViewModel(
         itemsLiveData?.value?.let {
             val newPosition = impression.positionMap[NewsItem.DEFAULT_SUB_CATEGORY_ID] ?: 0
             val lastPosition = categoryItemsShownMap[impression.category] ?: 0
-            if (newPosition != 0 && newPosition > lastPosition && (((newPosition - lastPosition) > DEFAULT_PAGE_SIZE) || impression.significant)) {
+            if (newPosition != 0 && newPosition > lastPosition && newPosition <= it.size && (((newPosition - lastPosition) > DEFAULT_PAGE_SIZE) || impression.significant)) {
                 trackNewsItemsShown(it.subList(lastPosition, newPosition))
                 categoryItemsShownMap[impression.category] = newPosition
             }


### PR DESCRIPTION
```
Fatal Exception: java.lang.IndexOutOfBoundsException
toIndex = 35
java.util.SubList.<init> (AbstractList.java:622)
java.util.AbstractList.subList (AbstractList.java:486)
org.mozilla.rocket.content.news.ui.NewsViewModel$onNewsItemsShown$1.invokeSuspend (NewsViewModel.kt:71)
kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith (ContinuationImpl.kt:33)
kotlinx.coroutines.DispatchedTask.run (DispatchedTask.kt:56)
kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely (CoroutineScheduler.kt:571)
kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask (CoroutineScheduler.kt:738)
kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker (CoroutineScheduler.kt:678)
kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run (CoroutineScheduler.kt:665)
```