### PR TITLE
Try to fix NPE from TabModelStore.saveWebViewState

### DIFF
--- a/app/src/main/java/org/mozilla/focus/persistence/TabModelStore.java
+++ b/app/src/main/java/org/mozilla/focus/persistence/TabModelStore.java
@@ -2,7 +2,9 @@ package org.mozilla.focus.persistence;
 
 import android.content.Context;
 import android.os.AsyncTask;
+import android.os.Bundle;
 import android.preference.PreferenceManager;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -155,13 +157,15 @@ public class TabModelStore {
             final List<File> updateFileList = new ArrayList<>();
 
             for (Session session : sessionList) {
-                if (session != null
-                        && session.getEngineSession() != null
-                        && session.getEngineSession().getWebViewState() != null) {
+                final String sessionId = (session != null) ? session.getId() : null;
+                final TabViewEngineSession engineSession = (session != null) ? session.getEngineSession() : null;
+                final Bundle webViewState = (engineSession != null) ? engineSession.getWebViewState() : null;
+
+                if (sessionId != null && webViewState != null) {
                     FileUtils.writeBundleToStorage(cacheDir,
-                            session.getId(),
-                            session.getEngineSession().getWebViewState());
-                    updateFileList.add(new File(cacheDir, session.getId()));
+                            sessionId,
+                            webViewState);
+                    updateFileList.add(new File(cacheDir, sessionId));
                 }
             }
 


### PR DESCRIPTION
```
Caused by java.lang.NullPointerException
Attempt to invoke virtual method 'android.os.Bundle org.mozilla.rocket.tabs.TabViewEngineSession.getWebViewState()' on a null object reference
org.mozilla.focus.persistence.TabModelStore$SaveTabsTask.saveWebViewState (TabModelStore.java:163)
org.mozilla.focus.persistence.TabModelStore$SaveTabsTask.doInBackground (TabModelStore.java:134)
org.mozilla.focus.persistence.TabModelStore$SaveTabsTask.doInBackground (TabModelStore.java:117)
android.os.AsyncTask$2.call (AsyncTask.java:298)
java.util.concurrent.FutureTask.run (FutureTask.java:237)
android.os.AsyncTask$SerialExecutor$1.run (AsyncTask.java:237)
java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1113)
java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:588)
java.lang.Thread.run (Thread.java:818)
```