### PR TITLE
Download Telemetry 

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -236,6 +236,7 @@
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.DOWNLOAD_COMPLETE"/>
+                <action android:name="android.intent.action.ACTION_NOTIFICATION_CLICKED"/>
             </intent-filter>
         </receiver>
 

--- a/app/src/main/java/org/mozilla/focus/components/DownloadCompleteReceiver.java
+++ b/app/src/main/java/org/mozilla/focus/components/DownloadCompleteReceiver.java
@@ -31,7 +31,7 @@ public class DownloadCompleteReceiver extends BroadcastReceiver {
         }
         DownloadInfoManager.DownloadPojo downloadPojo = DownloadInfoManager.getInstance().queryDownloadManager(downloadId);
         // Download completed with a record in DM.
-        // This means it's aborted automatically or download compelted.
+        // This means it's aborted automatically or download completed.
         // If it's stopped in the notification, the event will be send out later.
         if (downloadPojo != null) {
             TelemetryWrapper.endDownloadFile(String.valueOf(downloadId),
@@ -39,12 +39,6 @@ public class DownloadCompleteReceiver extends BroadcastReceiver {
                     downloadPojo.sizeSoFar / (downloadPojo.length + 1),
                     downloadPojo.reason,
                     downloadPojo.status);
-        } else {
-            TelemetryWrapper.endDownloadFile(String.valueOf(downloadId),
-                    "-1",
-                    0,
-                    0,
-                    DownloadInfo.STATUS_DELETED);
         }
 
         DownloadInfoManager.getInstance().queryByDownloadId(downloadId, new DownloadInfoManager.AsyncQueryListener() {
@@ -52,6 +46,14 @@ public class DownloadCompleteReceiver extends BroadcastReceiver {
             public void onQueryComplete(List downloadInfoList) {
                 if (downloadInfoList.size() > 0) {
                     final DownloadInfo downloadInfo = (DownloadInfo) downloadInfoList.get(0);
+                    if (downloadInfo.getStatus() != DownloadManager.STATUS_SUCCESSFUL) {
+                        // there's data in DB, this means deletion happens outside of our UI
+                        TelemetryWrapper.endDownloadFile(String.valueOf(downloadId),
+                                "-1",
+                                0,
+                                0,
+                                DownloadInfo.STATUS_DELETED);
+                    }
                     if ((downloadInfo.getStatus() == DownloadManager.STATUS_SUCCESSFUL)
                             && !TextUtils.isEmpty(downloadInfo.getFileUri())) {
 

--- a/app/src/main/java/org/mozilla/focus/components/DownloadCompleteReceiver.java
+++ b/app/src/main/java/org/mozilla/focus/components/DownloadCompleteReceiver.java
@@ -34,11 +34,11 @@ public class DownloadCompleteReceiver extends BroadcastReceiver {
         // This means it's aborted automatically or download completed.
         // If it's stopped in the notification, the event will be send out later.
         if (downloadPojo != null) {
-            TelemetryWrapper.endDownloadFile(String.valueOf(downloadId),
-                    downloadPojo.length + "",
-                    downloadPojo.sizeSoFar / (downloadPojo.length + 1),
-                    downloadPojo.reason,
-                    downloadPojo.status);
+            TelemetryWrapper.endDownloadFile(downloadId,
+                    downloadPojo.length,
+                    downloadPojo.sizeSoFar / (downloadPojo.length + 1) * 100,
+                    downloadPojo.status,
+                    downloadPojo.reason);
         }
 
         DownloadInfoManager.getInstance().queryByDownloadId(downloadId, new DownloadInfoManager.AsyncQueryListener() {
@@ -48,11 +48,13 @@ public class DownloadCompleteReceiver extends BroadcastReceiver {
                     final DownloadInfo downloadInfo = (DownloadInfo) downloadInfoList.get(0);
                     if (downloadInfo.getStatus() != DownloadManager.STATUS_SUCCESSFUL) {
                         // there's data in DB, this means deletion happens outside of our UI
-                        TelemetryWrapper.endDownloadFile(String.valueOf(downloadId),
-                                "-1",
+                        // when we delete the download, we also remove it from DM. So we can't get
+                        // the file size and progress anymore.
+                        TelemetryWrapper.endDownloadFile(downloadId,
+                                -1,
                                 0,
-                                0,
-                                DownloadInfo.STATUS_DELETED);
+                                DownloadInfo.STATUS_DELETED,
+                                DownloadInfo.REASON_DEFAULT);
                     }
                     if ((downloadInfo.getStatus() == DownloadManager.STATUS_SUCCESSFUL)
                             && !TextUtils.isEmpty(downloadInfo.getFileUri())) {

--- a/app/src/main/java/org/mozilla/focus/components/DownloadCompleteReceiver.java
+++ b/app/src/main/java/org/mozilla/focus/components/DownloadCompleteReceiver.java
@@ -34,9 +34,10 @@ public class DownloadCompleteReceiver extends BroadcastReceiver {
         // This means it's aborted automatically or download completed.
         // If it's stopped in the notification, the event will be send out later.
         if (downloadPojo != null) {
+            double progress = downloadPojo.length != 0.0 ? downloadPojo.sizeSoFar * 100.0 / downloadPojo.length : 0.0;
             TelemetryWrapper.endDownloadFile(downloadId,
                     downloadPojo.length,
-                    downloadPojo.sizeSoFar / (downloadPojo.length + 1) * 100,
+                    progress,
                     downloadPojo.status,
                     downloadPojo.reason);
         }
@@ -51,7 +52,7 @@ public class DownloadCompleteReceiver extends BroadcastReceiver {
                         // when we delete the download, we also remove it from DM. So we can't get
                         // the file size and progress anymore.
                         TelemetryWrapper.endDownloadFile(downloadId,
-                                -1,
+                                0,
                                 0,
                                 DownloadInfo.STATUS_DELETED,
                                 DownloadInfo.REASON_DEFAULT);

--- a/app/src/main/java/org/mozilla/focus/components/DownloadCompleteReceiver.java
+++ b/app/src/main/java/org/mozilla/focus/components/DownloadCompleteReceiver.java
@@ -15,6 +15,7 @@ import android.text.TextUtils;
 
 import org.mozilla.focus.download.DownloadInfo;
 import org.mozilla.focus.download.DownloadInfoManager;
+import org.mozilla.focus.telemetry.TelemetryWrapper;
 import org.mozilla.threadutils.ThreadUtils;
 
 import java.io.File;
@@ -27,6 +28,23 @@ public class DownloadCompleteReceiver extends BroadcastReceiver {
 
         if (downloadId == -1) {
             return;
+        }
+        DownloadInfoManager.DownloadPojo downloadPojo = DownloadInfoManager.getInstance().queryDownloadManager(downloadId);
+        // Download completed with a record in DM.
+        // This means it's aborted automatically or download compelted.
+        // If it's stopped in the notification, the event will be send out later.
+        if (downloadPojo != null) {
+            TelemetryWrapper.endDownloadFile(String.valueOf(downloadId),
+                    downloadPojo.length + "",
+                    downloadPojo.sizeSoFar / (downloadPojo.length + 1),
+                    downloadPojo.reason,
+                    downloadPojo.status);
+        } else {
+            TelemetryWrapper.endDownloadFile(String.valueOf(downloadId),
+                    "-1",
+                    0,
+                    0,
+                    DownloadInfo.STATUS_DELETED);
         }
 
         DownloadInfoManager.getInstance().queryByDownloadId(downloadId, new DownloadInfoManager.AsyncQueryListener() {

--- a/app/src/main/java/org/mozilla/focus/download/DownloadInfo.java
+++ b/app/src/main/java/org/mozilla/focus/download/DownloadInfo.java
@@ -26,6 +26,7 @@ public class DownloadInfo {
     private Long RowId;
     private Long DownloadId;
     private int Status;
+    private int reason;
     private String Size;
     private String Date;
     private String FileName = "";
@@ -56,6 +57,14 @@ public class DownloadInfo {
 
     public String getFileExtension() {
         return FileExtension;
+    }
+
+    public void setReason(int reason) {
+        this.reason = reason;
+    }
+
+    public int getReason() {
+        return this.reason;
     }
 
     public void setStatusInt(int status) {

--- a/app/src/main/java/org/mozilla/focus/download/DownloadInfo.java
+++ b/app/src/main/java/org/mozilla/focus/download/DownloadInfo.java
@@ -22,6 +22,7 @@ public class DownloadInfo {
     // DownloadManager.COLUMN_STATUS field is not available because no matching entry is available
     // in the DownloadManager's table.
     public static final int STATUS_DELETED = -1;
+    public static final int REASON_DEFAULT = -2;
 
     private Long RowId;
     private Long DownloadId;

--- a/app/src/main/java/org/mozilla/focus/download/DownloadInfoManager.java
+++ b/app/src/main/java/org/mozilla/focus/download/DownloadInfoManager.java
@@ -454,11 +454,6 @@ public class DownloadInfoManager {
         return pojo;
     }
 
-    public String getNetwork(){
-        ConnectivityManager cm = ((ConnectivityManager) mContext.getSystemService(Context.CONNECTIVITY_SERVICE));
-        return cm.isActiveNetworkMetered() ? "mobile" : "wifi";
-    }
-
     /* Data class to store queried information from DownloadManager */
     public static class DownloadPojo {
         long downloadId;

--- a/app/src/main/java/org/mozilla/focus/download/DownloadInfoManager.java
+++ b/app/src/main/java/org/mozilla/focus/download/DownloadInfoManager.java
@@ -405,6 +405,7 @@ public class DownloadInfoManager {
         info.setDownloadId(downloadId);
         info.setFileUri(fileUri);
         info.setStatusInt(DownloadInfo.STATUS_DELETED);
+        info.setStatusInt(DownloadInfo.REASON_DEFAULT);
         return info;
     }
 

--- a/app/src/main/java/org/mozilla/focus/download/DownloadInfoManager.java
+++ b/app/src/main/java/org/mozilla/focus/download/DownloadInfoManager.java
@@ -430,8 +430,8 @@ public class DownloadInfoManager {
                 pojo.desc = managerCursor.getString(managerCursor.getColumnIndex(DownloadManager.COLUMN_DESCRIPTION));
                 pojo.status = managerCursor.getInt(managerCursor.getColumnIndex(DownloadManager.COLUMN_STATUS));
                 pojo.reason = managerCursor.getInt(managerCursor.getColumnIndex(DownloadManager.COLUMN_REASON));
-                pojo.length = managerCursor.getDouble(managerCursor.getColumnIndex(DownloadManager.COLUMN_TOTAL_SIZE_BYTES));
-                pojo.sizeSoFar = managerCursor.getDouble(managerCursor.getColumnIndex(DownloadManager.COLUMN_BYTES_DOWNLOADED_SO_FAR));
+                pojo.length = managerCursor.getLong(managerCursor.getColumnIndex(DownloadManager.COLUMN_TOTAL_SIZE_BYTES));
+                pojo.sizeSoFar = managerCursor.getLong(managerCursor.getColumnIndex(DownloadManager.COLUMN_BYTES_DOWNLOADED_SO_FAR));
                 pojo.timeStamp = managerCursor.getLong(managerCursor.getColumnIndex(DownloadManager.COLUMN_LAST_MODIFIED_TIMESTAMP));
                 pojo.mediaUri = managerCursor.getString(managerCursor.getColumnIndex(DownloadManager.COLUMN_MEDIAPROVIDER_URI));
                 pojo.fileUri = managerCursor.getString(managerCursor.getColumnIndex(DownloadManager.COLUMN_LOCAL_URI));
@@ -460,8 +460,8 @@ public class DownloadInfoManager {
         long downloadId;
         String desc;
         String mime;
-        public double length;
-        public double sizeSoFar;
+        public long length;
+        public long sizeSoFar;
         public int status;
         public int reason;
         public long timeStamp;

--- a/app/src/main/java/org/mozilla/focus/download/DownloadInfoManager.java
+++ b/app/src/main/java/org/mozilla/focus/download/DownloadInfoManager.java
@@ -12,6 +12,7 @@ import android.content.ContentValues;
 import android.content.Context;
 import android.content.Intent;
 import android.database.Cursor;
+import android.net.ConnectivityManager;
 import android.net.Uri;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -382,6 +383,7 @@ public class DownloadInfoManager {
         info.setSizeTotal(pojo.length);
         info.setSizeSoFar(pojo.sizeSoFar);
         info.setStatusInt(pojo.status);
+        info.setReason(pojo.reason);
         info.setDate(pojo.timeStamp);
         info.setMediaUri(pojo.mediaUri);
         info.setFileUri(pojo.fileUri);
@@ -407,6 +409,11 @@ public class DownloadInfoManager {
     }
 
     @Nullable
+    public DownloadPojo queryDownloadManager(final long downloadId) {
+        return queryDownloadManager(mContext, downloadId);
+    }
+
+    @Nullable
     private static DownloadPojo queryDownloadManager(@NonNull final Context context, final long downloadId) {
 
         //query download manager
@@ -421,6 +428,7 @@ public class DownloadInfoManager {
             if (managerCursor != null && managerCursor.moveToFirst()) {
                 pojo.desc = managerCursor.getString(managerCursor.getColumnIndex(DownloadManager.COLUMN_DESCRIPTION));
                 pojo.status = managerCursor.getInt(managerCursor.getColumnIndex(DownloadManager.COLUMN_STATUS));
+                pojo.reason = managerCursor.getInt(managerCursor.getColumnIndex(DownloadManager.COLUMN_REASON));
                 pojo.length = managerCursor.getDouble(managerCursor.getColumnIndex(DownloadManager.COLUMN_TOTAL_SIZE_BYTES));
                 pojo.sizeSoFar = managerCursor.getDouble(managerCursor.getColumnIndex(DownloadManager.COLUMN_BYTES_DOWNLOADED_SO_FAR));
                 pojo.timeStamp = managerCursor.getLong(managerCursor.getColumnIndex(DownloadManager.COLUMN_LAST_MODIFIED_TIMESTAMP));
@@ -446,15 +454,21 @@ public class DownloadInfoManager {
         return pojo;
     }
 
+    public String getNetwork(){
+        ConnectivityManager cm = ((ConnectivityManager) mContext.getSystemService(Context.CONNECTIVITY_SERVICE));
+        return cm.isActiveNetworkMetered() ? "mobile" : "wifi";
+    }
+
     /* Data class to store queried information from DownloadManager */
-    private static class DownloadPojo {
+    public static class DownloadPojo {
         long downloadId;
         String desc;
         String mime;
-        double length;
-        double sizeSoFar;
-        int status;
-        long timeStamp;
+        public double length;
+        public double sizeSoFar;
+        public int status;
+        public int reason;
+        public long timeStamp;
         String mediaUri;
         String fileUri;
         String fileExtension;

--- a/app/src/main/java/org/mozilla/focus/download/EnqueueDownloadTask.java
+++ b/app/src/main/java/org/mozilla/focus/download/EnqueueDownloadTask.java
@@ -7,6 +7,7 @@ import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Environment;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -108,9 +109,9 @@ public class EnqueueDownloadTask extends AsyncTask<Void, Void, EnqueueDownloadTa
                             GetDownloadFileHeaderTask.HeaderInfo headerInfo = new GetDownloadFileHeaderTask().execute(download.getUrl()).get();
                             TelemetryWrapper.startDownloadFile(downloadInfo.getDownloadId().toString(), download.getContentLength() / 1024, headerInfo.isValidSSL, headerInfo.isSupportRange);
                         } catch (ExecutionException e) {
-                            Log.e(TAG,"Fail sending download telemetry because ExecutionException");
+                            Log.e(TAG, "Fail sending download telemetry because ExecutionException");
                         } catch (InterruptedException e) {
-                            Log.e(TAG,"Fail sending download telemetry because InterruptedException");
+                            Log.e(TAG, "Fail sending download telemetry because InterruptedException");
                         }
 
                         DownloadInfoManager.notifyRowUpdated(context, id);

--- a/app/src/main/java/org/mozilla/focus/download/EnqueueDownloadTask.java
+++ b/app/src/main/java/org/mozilla/focus/download/EnqueueDownloadTask.java
@@ -106,7 +106,7 @@ public class EnqueueDownloadTask extends AsyncTask<Void, Void, EnqueueDownloadTa
                     public void onInsertComplete(long id) {
                         try {
                             GetDownloadFileHeaderTask.HeaderInfo headerInfo = new GetDownloadFileHeaderTask().execute(download.getUrl()).get();
-                            TelemetryWrapper.startDownloadFile(downloadInfo.getDownloadId().toString(), headerInfo.isSupportSSL, headerInfo.isSupportRange);
+                            TelemetryWrapper.startDownloadFile(downloadInfo.getDownloadId().toString(), download.getContentLength() / 1024, headerInfo.isValidSSL, headerInfo.isSupportRange);
                         } catch (ExecutionException e) {
                             Log.e(TAG,"Fail sending download telemetry because ExecutionException");
                         } catch (InterruptedException e) {

--- a/app/src/main/java/org/mozilla/focus/download/GetDownloadFileHeaderTask.java
+++ b/app/src/main/java/org/mozilla/focus/download/GetDownloadFileHeaderTask.java
@@ -4,6 +4,7 @@ import android.net.TrafficStats;
 import android.os.AsyncTask;
 
 import org.mozilla.focus.network.SocketTags;
+import org.mozilla.focus.utils.AppConstants;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
@@ -24,6 +25,9 @@ public class GetDownloadFileHeaderTask extends AsyncTask<String, Void, GetDownlo
         TrafficStats.setThreadStatsTag(SocketTags.DOWNLOADS);
         HttpURLConnection connection = null;
         HeaderInfo headerInfo = new HeaderInfo();
+        if (AppConstants.isDevBuild()) {
+            return headerInfo;
+        }
         try {
             connection = (HttpURLConnection) new URL(params[0]).openConnection();
             connection.setRequestMethod("HEAD");

--- a/app/src/main/java/org/mozilla/focus/download/GetDownloadFileHeaderTask.java
+++ b/app/src/main/java/org/mozilla/focus/download/GetDownloadFileHeaderTask.java
@@ -1,0 +1,58 @@
+package org.mozilla.focus.download;
+
+import android.net.TrafficStats;
+import android.os.AsyncTask;
+
+import org.mozilla.focus.network.SocketTags;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import javax.net.ssl.SSLHandshakeException;
+
+
+public class GetDownloadFileHeaderTask extends AsyncTask<String, Void, GetDownloadFileHeaderTask.HeaderInfo> {
+
+    public static class HeaderInfo {
+        boolean isSupportRange;
+        boolean isSupportSSL;
+    }
+
+    @Override
+    protected HeaderInfo doInBackground(String... params) {
+        TrafficStats.setThreadStatsTag(SocketTags.DOWNLOADS);
+        HttpURLConnection connection = null;
+        boolean supportRange = false;
+        boolean isSSL = true;
+        int responseCode = 0;
+        try {
+            connection = (HttpURLConnection) new URL(params[0]).openConnection();
+            connection.setRequestMethod("HEAD");
+            String headerField = connection.getHeaderField("Accept-Ranges");
+            if (headerField != null && headerField.equals("bytes")) {
+                supportRange = true;
+            }
+            responseCode = connection.getResponseCode();
+            connection.disconnect();
+
+        } catch (SSLHandshakeException e) {
+            isSSL = false;
+        } catch (IOException e) {
+            e.printStackTrace();
+        } finally {
+            if (connection != null) {
+                connection.disconnect();
+            }
+        }
+
+        if (responseCode == HttpURLConnection.HTTP_OK) {
+            HeaderInfo headerInfo = new HeaderInfo();
+            headerInfo.isSupportRange = supportRange;
+            headerInfo.isSupportSSL = isSSL;
+            return headerInfo;
+        } else {
+            return null;
+        }
+    }
+}

--- a/app/src/main/java/org/mozilla/focus/download/GetDownloadFileHeaderTask.java
+++ b/app/src/main/java/org/mozilla/focus/download/GetDownloadFileHeaderTask.java
@@ -15,29 +15,27 @@ import javax.net.ssl.SSLHandshakeException;
 public class GetDownloadFileHeaderTask extends AsyncTask<String, Void, GetDownloadFileHeaderTask.HeaderInfo> {
 
     public static class HeaderInfo {
-        boolean isSupportRange;
-        boolean isSupportSSL;
+        boolean isSupportRange = false;
+        boolean isValidSSL = true;
     }
 
     @Override
     protected HeaderInfo doInBackground(String... params) {
         TrafficStats.setThreadStatsTag(SocketTags.DOWNLOADS);
         HttpURLConnection connection = null;
-        boolean supportRange = false;
-        boolean isSSL = true;
-        int responseCode = 0;
+        HeaderInfo headerInfo = new HeaderInfo();
         try {
             connection = (HttpURLConnection) new URL(params[0]).openConnection();
             connection.setRequestMethod("HEAD");
             String headerField = connection.getHeaderField("Accept-Ranges");
             if (headerField != null && headerField.equals("bytes")) {
-                supportRange = true;
+                headerInfo.isSupportRange = true;
             }
-            responseCode = connection.getResponseCode();
+            connection.getResponseCode();
             connection.disconnect();
 
         } catch (SSLHandshakeException e) {
-            isSSL = false;
+            headerInfo.isValidSSL = false;
         } catch (IOException e) {
             e.printStackTrace();
         } finally {
@@ -45,14 +43,6 @@ public class GetDownloadFileHeaderTask extends AsyncTask<String, Void, GetDownlo
                 connection.disconnect();
             }
         }
-
-        if (responseCode == HttpURLConnection.HTTP_OK) {
-            HeaderInfo headerInfo = new HeaderInfo();
-            headerInfo.isSupportRange = supportRange;
-            headerInfo.isSupportSSL = isSSL;
-            return headerInfo;
-        } else {
-            return null;
-        }
+        return headerInfo;
     }
 }

--- a/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
+++ b/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
@@ -57,6 +57,7 @@ import org.mozilla.telemetry.serialize.JSONPingSerializer
 import org.mozilla.telemetry.storage.FileTelemetryStorage
 import org.mozilla.threadutils.ThreadUtils
 import java.util.concurrent.atomic.AtomicInteger
+import kotlin.math.roundToInt
 
 object TelemetryWrapper {
     private const val TELEMETRY_APP_NAME_ZERDA = "Zerda"
@@ -4030,11 +4031,13 @@ object TelemetryWrapper {
     @JvmStatic
     fun startDownloadFile(
         downloadId: String,
+        fileSize: Double,
         isValidSSL: Boolean,
         isSupportRange: Boolean
     ) {
         EventBuilder(Category.ACTION, Method.START, Object.DOWNLOAD, Value.FILE)
             .extra(Extra.DOWNLOAD_ID, downloadId)
+            .extra(Extra.FILE_SIZE, (fileSize / 1024).toString())
             .extra(Extra.START_TIME, System.currentTimeMillis().toString())
             .extra(Extra.SUPPORT_RESUME, isSupportRange.toString())
             .extra(Extra.VALID_SSL, isValidSSL.toString())
@@ -4058,17 +4061,17 @@ object TelemetryWrapper {
     )
     @JvmStatic
     fun endDownloadFile(
-        downloadId: String,
-        fileSize: String,
+        downloadId: Long,
+        fileSize: Double,
         progress: Double,
         status: Int,
         reason: Int
     ) {
         EventBuilder(Category.ACTION, Method.END, Object.DOWNLOAD, Value.FILE)
-            .extra(Extra.DOWNLOAD_ID, downloadId)
+            .extra(Extra.DOWNLOAD_ID, downloadId.toString())
             .extra(Extra.END_TIME, System.currentTimeMillis().toString())
-            .extra(Extra.FILE_SIZE, fileSize.toString())
-            .extra(Extra.PROGRESS, progress.toString())
+            .extra(Extra.FILE_SIZE, (fileSize / 1024).toString())
+            .extra(Extra.PROGRESS, progress.roundToInt().toString())
             .extra(Extra.STATUS, status.toString())
             .extra(Extra.REASON, reason.toString())
             .extra(Extra.NETWORK, network())

--- a/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
+++ b/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
@@ -4031,7 +4031,7 @@ object TelemetryWrapper {
     @JvmStatic
     fun startDownloadFile(
         downloadId: String,
-        fileSize: Double,
+        fileSize: Long,
         isValidSSL: Boolean,
         isSupportRange: Boolean
     ) {
@@ -4062,7 +4062,7 @@ object TelemetryWrapper {
     @JvmStatic
     fun endDownloadFile(
         downloadId: Long,
-        fileSize: Double,
+        fileSize: Long,
         progress: Double,
         status: Int,
         reason: Int

--- a/app/src/main/java/org/mozilla/rocket/download/DownloadInfoRepository.kt
+++ b/app/src/main/java/org/mozilla/rocket/download/DownloadInfoRepository.kt
@@ -83,11 +83,11 @@ class DownloadInfoRepository {
         val downloadPojo =
             DownloadInfoManager.getInstance().queryDownloadManager(downloadId) ?: return
         TelemetryWrapper.endDownloadFile(
-            downloadId.toString(),
-            downloadPojo.length.toString(),
-            downloadPojo.sizeSoFar / downloadPojo.length * 100,
-            -1,
-            -1
+            downloadId,
+            downloadPojo.length,
+            downloadPojo.sizeSoFar / (downloadPojo.length + 1) * 100,
+            DownloadInfo.STATUS_DELETED,
+            DownloadInfo.REASON_DEFAULT
         )
         DownloadInfoManager.getInstance().downloadManager.remove(downloadId)
     }

--- a/app/src/main/java/org/mozilla/rocket/download/DownloadInfoRepository.kt
+++ b/app/src/main/java/org/mozilla/rocket/download/DownloadInfoRepository.kt
@@ -82,10 +82,15 @@ class DownloadInfoRepository {
 
         val downloadPojo =
             DownloadInfoManager.getInstance().queryDownloadManager(downloadId) ?: return
+        val progress = if (downloadPojo.length == 0L) {
+            0.0
+        } else {
+            downloadPojo.sizeSoFar.times(100).toDouble() / downloadPojo.length
+        }
         TelemetryWrapper.endDownloadFile(
             downloadId,
             downloadPojo.length,
-            downloadPojo.sizeSoFar / (downloadPojo.length + 1) * 100,
+            progress,
             DownloadInfo.STATUS_DELETED,
             DownloadInfo.REASON_DEFAULT
         )

--- a/app/src/main/java/org/mozilla/rocket/download/DownloadInfoRepository.kt
+++ b/app/src/main/java/org/mozilla/rocket/download/DownloadInfoRepository.kt
@@ -3,6 +3,7 @@ package org.mozilla.rocket.download
 import android.app.DownloadManager
 import org.mozilla.focus.download.DownloadInfo
 import org.mozilla.focus.download.DownloadInfoManager
+import org.mozilla.focus.telemetry.TelemetryWrapper
 import org.mozilla.threadutils.ThreadUtils
 
 class DownloadInfoRepository {
@@ -77,7 +78,16 @@ class DownloadInfoRepository {
         DownloadInfoManager.getInstance().delete(rowId, null)
     }
 
-    fun deleteFromDownloadManager(downloadId: Long) {
-        DownloadInfoManager.getInstance().downloadManager.remove(downloadId)
+    fun recordDownloadDeletion(downloadId: Long) {
+
+        val downloadPojo =
+            DownloadInfoManager.getInstance().queryDownloadManager(downloadId) ?: return
+        TelemetryWrapper.endDownloadFile(
+            downloadId.toString(),
+            downloadPojo.length.toString(),
+            downloadPojo.sizeSoFar / downloadPojo.length * 100,
+            downloadPojo.reason,
+            downloadPojo.status
+        )
     }
 }

--- a/app/src/main/java/org/mozilla/rocket/download/DownloadInfoRepository.kt
+++ b/app/src/main/java/org/mozilla/rocket/download/DownloadInfoRepository.kt
@@ -78,7 +78,7 @@ class DownloadInfoRepository {
         DownloadInfoManager.getInstance().delete(rowId, null)
     }
 
-    fun recordDownloadDeletion(downloadId: Long) {
+    fun deleteFromDownloadManager(downloadId: Long) {
 
         val downloadPojo =
             DownloadInfoManager.getInstance().queryDownloadManager(downloadId) ?: return
@@ -86,8 +86,9 @@ class DownloadInfoRepository {
             downloadId.toString(),
             downloadPojo.length.toString(),
             downloadPojo.sizeSoFar / downloadPojo.length * 100,
-            downloadPojo.reason,
-            downloadPojo.status
+            -1,
+            -1
         )
+        DownloadInfoManager.getInstance().downloadManager.remove(downloadId)
     }
 }

--- a/app/src/main/java/org/mozilla/rocket/download/DownloadInfoViewModel.kt
+++ b/app/src/main/java/org/mozilla/rocket/download/DownloadInfoViewModel.kt
@@ -112,7 +112,7 @@ class DownloadInfoViewModel(private val repository: DownloadInfoRepository) : Vi
                 if (download.existInDownloadManager()) {
                     if (rowId == download.rowId && DownloadManager.STATUS_SUCCESSFUL != download.status) {
                         toastMessageObservable.value = R.string.download_cancel
-                        repository.deleteFromDownloadManager(download.downloadId)
+                        repository.recordDownloadDeletion(download.downloadId)
                         remove(rowId)
                     }
                 }
@@ -147,7 +147,7 @@ class DownloadInfoViewModel(private val repository: DownloadInfoRepository) : Vi
         try {
             val deleteFile = File(URI(download.fileUri).path)
             if (deleteFile.delete()) {
-                repository.deleteFromDownloadManager(download.downloadId)
+                repository.recordDownloadDeletion(download.downloadId)
                 repository.remove(download.rowId)
             } else {
                 toastMessageObservable.value = R.string.cannot_delete_the_file

--- a/app/src/main/java/org/mozilla/rocket/download/DownloadInfoViewModel.kt
+++ b/app/src/main/java/org/mozilla/rocket/download/DownloadInfoViewModel.kt
@@ -112,7 +112,7 @@ class DownloadInfoViewModel(private val repository: DownloadInfoRepository) : Vi
                 if (download.existInDownloadManager()) {
                     if (rowId == download.rowId && DownloadManager.STATUS_SUCCESSFUL != download.status) {
                         toastMessageObservable.value = R.string.download_cancel
-                        repository.recordDownloadDeletion(download.downloadId)
+                        repository.deleteFromDownloadManager(download.downloadId)
                         remove(rowId)
                     }
                 }
@@ -147,7 +147,7 @@ class DownloadInfoViewModel(private val repository: DownloadInfoRepository) : Vi
         try {
             val deleteFile = File(URI(download.fileUri).path)
             if (deleteFile.delete()) {
-                repository.recordDownloadDeletion(download.downloadId)
+                repository.deleteFromDownloadManager(download.downloadId)
                 repository.remove(download.rowId)
             } else {
                 toastMessageObservable.value = R.string.cannot_delete_the_file

--- a/docs/events.md
+++ b/docs/events.md
@@ -210,3 +210,5 @@
 |Show Set-Default Success Toast|action|show|toast|"set_default_success"|"" 
 |Show Set-Default Try-again Snackbar|action|show|snackbar|"set_default_try_again"|"" 
 |Click Set-Default Try-again Snackbar|action|click|snackbar|"set_default_try_again"|"action=try_again," 
+|Start Download File|action|start|download|"file"|"download_id=1,2,3...,start_time=timestamp,support_resume=true,false,valid_ssl=true,false,network=mobile/wifi," 
+|End Download File|action|end|download|"file"|"download_id=1,2,3...,end_time=timestamp,file_size=number,progress=number,status=1.3,reason=1005,1006,network=mobile/wifi," 

--- a/docs/view.sql
+++ b/docs/view.sql
@@ -234,6 +234,8 @@ SELECT
         WHEN (event_category IN ('action') ) AND (event_method IN ('show') ) AND (event_object IN ('toast') ) AND (event_value IN ('set_default_success') ) THEN 'Rocket -  Show Set-Default Success Toast' 
         WHEN (event_category IN ('action') ) AND (event_method IN ('show') ) AND (event_object IN ('snackbar') ) AND (event_value IN ('set_default_try_again') ) THEN 'Rocket -  Show Set-Default Try-again Snackbar' 
         WHEN (event_category IN ('action') ) AND (event_method IN ('click') ) AND (event_object IN ('snackbar') ) AND (event_value IN ('set_default_try_again') ) THEN 'Rocket -  Click Set-Default Try-again Snackbar' 
+        WHEN (event_category IN ('action') ) AND (event_method IN ('start') ) AND (event_object IN ('download') ) AND (event_value IN ('file') ) THEN 'Rocket -  Start Download File' 
+        WHEN (event_category IN ('action') ) AND (event_method IN ('end') ) AND (event_object IN ('download') ) AND (event_value IN ('file') ) THEN 'Rocket -  End Download File' 
 
     END AS event_name,
     event_timestamp AS timestamp,


### PR DESCRIPTION
### Telemetry Content


closes #5243

This is the possible result I've tested:
### Possible Value of Status / Reason
condition | status | reason
-- | -- | --
download complete normally | 8 | 0
web site refuse | 16 | 403(see the [document](https://developer.android.com/reference/android/app/DownloadManager.html#COLUMN_REASON) for why http status code is used)
no storage | 16 | 1006
use http instead of https | 16 | 1004
user delete file (from UI or notification) | -1(defined in our code) | -2 (defined in our code)


For detail value and steps, see below: (only scenarios marked `V` are covered)

- [x] Download a file from FxLite should see **action/start/download/file** . Sample:
EVENT:action/start/download/file
EXTRA:download_id/17056
EXTRA:file_size/1024.0
EXTRA:start_time/1594793713027
EXTRA:support_resume/true
EXTRA:valid_ssl/true
EXTRA:network/wifi

- [x] Download Completed
EVENT:action/end/download/file
EXTRA:download_id/(eg 17056)
EXTRA:end_time/(eg 1594793808988)
EXTRA:file_size/xxx (kb)
EXTRA:progress/100
EXTRA:status/8 (fix number)
EXTRA:reason/0 (fix number)
EXTRA:network/wifi

- [x] Cancel a download while it's downloading in our UI should see **action/end/download/file** . Sample:
EVENT:action/end/download/file
EXTRA:download_id/(eg 17056)
EXTRA:end_time/(eg 1594793808988)
EXTRA:file_size/xxx (kb)
EXTRA:progress/(0-100)
EXTRA:status/-1 (fix number)
EXTRA:reason/-2 (fix number)
EXTRA:network/wifi

- [x] Cancel a download while it's downloading in System's notification Tray(Status Bar) should see **action/end/download/file**. Sample:
EVENT:action/end/download/file
EXTRA:download_id/(eg 17056)
EXTRA:end_time/(eg 1594793808988)
EXTRA:file_size/0 (fix number)
EXTRA:progress/0 (fix number)
EXTRA:status/-1 (fix number)
EXTRA:reason/-2 (fix number)
EXTRA:network/wifi
  - [x] The app is in the foreground
  - [x] The app is in the background
  - [ ] The app is not in recent apps

- [ ] Cancel a download while it shows "paused" in our UI  [C1]
- [ ] Cancel a download while it shows "failed" in our UI 
- [ ] Distinguish `end file download` event between clicking our UI or the system's notificaiton

[C1] The download will continue when the situation is resolved. But there won't be an entry in our download panel. But this is outside of the scope of this bug.

### Reference
For other reason/status code. [See this](https://developer.android.com/reference/android/app/DownloadManager#COLUMN_STATUS) 
#### COLUMN_REASON
datatype | value | meaning | detail
-- | -- | -- | --
int | 1008 | ERROR_CANNOT_RESUME | Value of COLUMN_REASON when some possibly transient error occurred but we can't resume the download.
int | 1007 | ERROR_DEVICE_NOT_FOUND | Value of COLUMN_REASON when no external storage device was found.
int | 1009 | ERROR_FILE_ALREADY_EXISTS | Value of COLUMN_REASON when the requested destination file already exists (the download manager will not overwrite an existing file).
int | 1001 | ERROR_FILE_ERROR | Value of COLUMN_REASON when a storage issue arises which doesn't fit under any other error code.
int | 1004 | ERROR_HTTP_DATA_ERROR | Value of COLUMN_REASON when an error receiving or processing data occurred at the HTTP level.
int | 1006 | ERROR_INSUFFICIENT_SPACE | Value of COLUMN_REASON when there was insufficient storage space.
int | 1005 | ERROR_TOO_MANY_REDIRECTS | Value of COLUMN_REASON when there were too many redirects.
int | 1002 | ERROR_UNHANDLED_HTTP_CODE | Value of COLUMN_REASON when an HTTP code was received that download manager can't handle.
int | 3 | PAUSED_QUEUED_FOR_WIFI | Value of COLUMN_REASON when the download exceeds a size limit for downloads over the mobile network and the download manager is waiting for a Wi-Fi connection to proceed.
int | 4 | PAUSED_UNKNOWN | Value of COLUMN_REASON when the download is paused for some other reason.
int | 2 | PAUSED_WAITING_FOR_NETWORK | Value of COLUMN_REASON when the download is waiting for network connectivity to proceed.
int | 1 | PAUSED_WAITING_TO_RETRY | Value of COLUMN_REASON when the download is paused because some network error occurred and the download manager is waiting before retrying the request.

#### COLUMN_STATUS
datatype | value | meaning | detail
-- | -- | -- | --
int | 16 | STATUS_FAILED | Value of COLUMN_STATUS when the download has failed (and will not be retried).
int | 4 | STATUS_PAUSED | Value of COLUMN_STATUS when the download is waiting to retry or resume.
int | 1 | STATUS_PENDING | Value of COLUMN_STATUS when the download is waiting to start.
int | 2 | STATUS_RUNNING | Value of COLUMN_STATUS when the download is currently running.
int | 8 | STATUS_SUCCESSFUL | Value of COLUMN_STATUS when the download has successfully completed.



