### PR TITLE
Fix a crash in 1.1.0-alpha05

### DIFF
--- a/app/src/main/res/layout/item_bucket_list.xml
+++ b/app/src/main/res/layout/item_bucket_list.xml
@@ -8,6 +8,7 @@
     android:layout_marginStart="16dp"
     android:layout_marginEnd="16dp"
     android:clipToPadding="false"
+    android:theme="@style/Theme.MaterialComponents.Light"
     app:cardCornerRadius="4dp"
     app:cardElevation="0dp"
     app:strokeColor="@color/paletteLightGreyA100"

--- a/app/src/main/res/layout/item_city.xml
+++ b/app/src/main/res/layout/item_city.xml
@@ -7,6 +7,7 @@
     android:layout_width="160dp"
     android:layout_height="wrap_content"
     android:clipToPadding="false"
+    android:theme="@style/Theme.MaterialComponents.Light"
     app:strokeColor="@color/paletteLightGreyA100"
     app:strokeWidth="1dp"
     app:cardCornerRadius="4dp"

--- a/app/src/main/res/layout/item_coupon.xml
+++ b/app/src/main/res/layout/item_coupon.xml
@@ -9,6 +9,7 @@
     android:layout_marginTop="8dp"
     android:layout_marginStart="16dp"
     android:layout_marginEnd="16dp"
+    android:theme="@style/Theme.MaterialComponents.Light"
     app:strokeColor="@color/paletteLightGreyA100"
     app:strokeWidth="1dp"
     app:cardCornerRadius="4dp"

--- a/app/src/main/res/layout/item_game.xml
+++ b/app/src/main/res/layout/item_game.xml
@@ -7,6 +7,7 @@
     android:layout_width="104dp"
     android:layout_height="wrap_content"
     android:clipToPadding="false"
+    android:theme="@style/Theme.MaterialComponents.Light"
     app:strokeColor="@color/paletteLightGreyA100"
     app:strokeWidth="1dp"
     app:cardCornerRadius="4dp"

--- a/app/src/main/res/layout/item_hotel.xml
+++ b/app/src/main/res/layout/item_hotel.xml
@@ -8,6 +8,7 @@
     android:layout_marginStart="16dp"
     android:layout_marginEnd="16dp"
     android:layout_marginBottom="8dp"
+    android:theme="@style/Theme.MaterialComponents.Light"
     app:cardCornerRadius="4dp"
     app:cardElevation="0dp"
     app:strokeColor="@color/paletteLightGreyA100"

--- a/app/src/main/res/layout/item_news.xml
+++ b/app/src/main/res/layout/item_news.xml
@@ -10,6 +10,7 @@
     android:layout_marginEnd="@dimen/common_margin_m3"
     android:layout_marginBottom="@dimen/common_margin_m2"
     android:clipToPadding="false"
+    android:theme="@style/Theme.MaterialComponents.Light"
     app:cardCornerRadius="4dp"
     app:cardElevation="0dp"
     app:strokeColor="@color/paletteLightGreyA100"

--- a/app/src/main/res/layout/item_product.xml
+++ b/app/src/main/res/layout/item_product.xml
@@ -7,6 +7,7 @@
     android:layout_width="160dp"
     android:layout_height="wrap_content"
     android:clipToPadding="false"
+    android:theme="@style/Theme.MaterialComponents.Light"
     app:strokeColor="@color/paletteLightGreyA100"
     app:strokeWidth="1dp"
     app:cardCornerRadius="4dp"

--- a/app/src/main/res/layout/item_voucher.xml
+++ b/app/src/main/res/layout/item_voucher.xml
@@ -8,6 +8,7 @@
     android:layout_height="wrap_content"
     android:minWidth="146dp"
     android:minHeight="146dp"
+    android:theme="@style/Theme.MaterialComponents.Light"
     app:strokeColor="@color/paletteLightGreyA100"
     app:strokeWidth="1dp"
     app:cardCornerRadius="12dp"


### PR DESCRIPTION
 where inflating MaterialCardView will introduce below error. Fix the issue according to the error message:

```
Caused by: java.lang.IllegalArgumentException: The style on this component requires your app theme to be Theme.MaterialComponents (or a descendant).
        at com.google.android.material.internal.ThemeEnforcement.checkTheme(ThemeEnforcement.java:240)
```

Tested: Travel/News/Games