### PR TITLE
Fix Download Telemetry

### DIFF
--- a/app/src/main/java/org/mozilla/focus/components/DownloadCompleteReceiver.java
+++ b/app/src/main/java/org/mozilla/focus/components/DownloadCompleteReceiver.java
@@ -52,8 +52,8 @@ public class DownloadCompleteReceiver extends BroadcastReceiver {
                         // when we delete the download, we also remove it from DM. So we can't get
                         // the file size and progress anymore.
                         TelemetryWrapper.endDownloadFile(downloadId,
-                                0,
-                                0,
+                                null,
+                                null,
                                 DownloadInfo.STATUS_DELETED,
                                 DownloadInfo.REASON_DEFAULT);
                     }

--- a/app/src/main/java/org/mozilla/focus/download/EnqueueDownloadTask.java
+++ b/app/src/main/java/org/mozilla/focus/download/EnqueueDownloadTask.java
@@ -107,7 +107,7 @@ public class EnqueueDownloadTask extends AsyncTask<Void, Void, EnqueueDownloadTa
                     public void onInsertComplete(long id) {
                         try {
                             GetDownloadFileHeaderTask.HeaderInfo headerInfo = new GetDownloadFileHeaderTask().execute(download.getUrl()).get();
-                            TelemetryWrapper.startDownloadFile(downloadInfo.getDownloadId().toString(), download.getContentLength() / 1024, headerInfo.isValidSSL, headerInfo.isSupportRange);
+                            TelemetryWrapper.startDownloadFile(downloadInfo.getDownloadId().toString(), download.getContentLength(), headerInfo.isValidSSL, headerInfo.isSupportRange);
                         } catch (ExecutionException e) {
                             Log.e(TAG, "Fail sending download telemetry because ExecutionException");
                         } catch (InterruptedException e) {

--- a/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
+++ b/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
@@ -4016,16 +4016,16 @@ object TelemetryWrapper {
     @JvmStatic
     fun endDownloadFile(
         downloadId: Long,
-        fileSize: Long,
-        progress: Double,
+        fileSize: Long?,
+        progress: Double?,
         status: Int,
         reason: Int
     ) {
         EventBuilder(Category.ACTION, Method.END, Object.DOWNLOAD, Value.FILE)
             .extra(Extra.DOWNLOAD_ID, downloadId.toString())
             .extra(Extra.END_TIME, System.currentTimeMillis().toString())
-            .extra(Extra.FILE_SIZE, (fileSize / 1024).toString())
-            .extra(Extra.PROGRESS, progress.roundToInt().toString())
+            .extra(Extra.FILE_SIZE, fileSize?.div(1024)?.toString() ?: "null")
+            .extra(Extra.PROGRESS, progress?.roundToInt()?.toString() ?: "null")
             .extra(Extra.STATUS, status.toString())
             .extra(Extra.REASON, reason.toString())
             .extra(Extra.NETWORK, network())


### PR DESCRIPTION
fix two bugs:
1. File size in `startDownloadFile` should be KB. not MB
2. If we receive download_complete event while deletion, record the file size and progress as `null` instead of `0`