### PR TITLE
Fix IllegalStateException on NewsFragment

### DIFF
--- a/app/src/main/java/org/mozilla/rocket/content/news/ui/NewsFragment.kt
+++ b/app/src/main/java/org/mozilla/rocket/content/news/ui/NewsFragment.kt
@@ -138,7 +138,8 @@ class NewsFragment : Fragment() {
 
     private fun bindNewsListData() {
         @Suppress("DEPRECATION")
-        if (!userVisibleHint || !this::newsAdapter.isInitialized || newsAdapter.itemCount != 0) {
+        // Make sure the fragment is visible and its lifecycle is after onCreateView()
+        if (!userVisibleHint || view == null || !this::newsAdapter.isInitialized || newsAdapter.itemCount != 0) {
             return
         }
 


### PR DESCRIPTION
```
Fatal Exception: java.lang.IllegalStateException
Can't access the Fragment View's LifecycleOwner when getView() is null i.e., before onCreateView() or after onDestroyView()
androidx.fragment.app.Fragment.getViewLifecycleOwner (Fragment.java:328)
org.mozilla.rocket.content.news.ui.NewsFragment.bindNewsListData (NewsFragment.kt:147)
org.mozilla.rocket.content.news.ui.NewsFragment.setUserVisibleHint (NewsFragment.kt:85)
androidx.fragment.app.FragmentPagerAdapter.setPrimaryItem (FragmentPagerAdapter.java:228)
androidx.viewpager.widget.ViewPager.populate (ViewPager.java:1234)
androidx.viewpager.widget.ViewPager.setCurrentItemInternal (ViewPager.java:669)
androidx.viewpager.widget.ViewPager.setCurrentItemInternal (ViewPager.java:631)
androidx.viewpager.widget.ViewPager.setCurrentItem (ViewPager.java:612)
com.google.android.material.tabs.TabLayout$ViewPagerOnTabSelectedListener.onTabSelected (TabLayout.java:3016)
com.google.android.material.tabs.TabLayout.dispatchTabSelected (TabLayout.java:1756)
com.google.android.material.tabs.TabLayout.selectTab (TabLayout.java:1749)
com.google.android.material.tabs.TabLayout.selectTab (TabLayout.java:1709)
com.google.android.material.tabs.TabLayout$Tab.select (TabLayout.java:2054)
com.google.android.material.tabs.TabLayout$TabView.performClick (TabLayout.java:2239)
android.view.View.performClickInternal (View.java:6585)
android.view.View.access$3100 (View.java:785)
android.view.View$PerformClick.run (View.java:25921)
android.os.Handler.handleCallback (Handler.java:873)
android.os.Handler.dispatchMessage (Handler.java:99)
android.os.Looper.loop (Looper.java:201)
android.app.ActivityThread.main (ActivityThread.java:6810)
java.lang.reflect.Method.invoke (Method.java)
com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:547)
com.android.internal.os.ZygoteInit.main (ZygoteInit.java:873)
```